### PR TITLE
fix file streamer with full path on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ BrainFlow is a library intended to obtain, parse and analyze EEG, EMG, ECG and o
 
 Compiled with:
 * MSVC on Windows
+* Android NDK with Ninja
 * GCC on Linux
 * Clang on MacOS
 
@@ -34,7 +35,7 @@ Compiled with:
 
 [![Build Status](https://travis-ci.com/brainflow-dev/brainflow.svg?branch=master)](https://travis-ci.com/brainflow-dev/brainflow)
 
-*Windows(AppVeyour)*:
+*Windows and Android NDK(AppVeyour)*:
 
 [![Build status](https://ci.appveyor.com/api/projects/status/nk6c8q4mcrfo9xgm/branch/master?svg=true)](https://ci.appveyor.com/project/Andrey1994/brainflow/branch/master)
 

--- a/docs/BuildBrainFlow.rst
+++ b/docs/BuildBrainFlow.rst
@@ -162,10 +162,8 @@ Note: Android Studio inline compiler may show red errors but it should be compil
     
     For some API calls you need to provide additional permissions via manifest file of your application ::
 
-        # for devices which use network
         <uses-permission android:name="android.permission.INTERNET"></uses-permission>
         <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"></uses-permission>
-        # to use read/write file from/to SD card
         <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"></uses-permission>
         <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
 

--- a/src/board_controller/board.cpp
+++ b/src/board_controller/board.cpp
@@ -92,8 +92,8 @@ int Board::prepare_streamer (char *streamer_params)
             return (int)BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR;
         }
         std::string streamer_type = streamer_params_str.substr (0, idx1);
-        size_t idx2 = streamer_params_str.find (":", idx1 + 3);
-        if (idx2 == std::string::npos)
+        size_t idx2 = streamer_params_str.find_last_of (":", std::string::npos);
+        if ((idx2 == std::string::npos) || (idx1 == idx2))
         {
             safe_logger (
                 spdlog::level::err, "format is streamer_type://streamer_dest:streamer_args");
@@ -104,6 +104,8 @@ int Board::prepare_streamer (char *streamer_params)
 
         if (streamer_type == "file")
         {
+            safe_logger (spdlog::level::trace, "File Streamer, file: {}, mods: {}",
+                streamer_dest.c_str (), streamer_mods.c_str ());
             streamer = new FileStreamer (streamer_dest.c_str (), streamer_mods.c_str ());
         }
         if (streamer_type == "streaming_board")


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

File streamer didnt work with full paths on windows because of multiple ':'