### PR TITLE
Unrecognised Escape Sequence compiler Warnings

### DIFF
--- a/src/board_controller/openbci/openbci_wifi_shield_board.cpp
+++ b/src/board_controller/openbci/openbci_wifi_shield_board.cpp
@@ -362,7 +362,7 @@ std::string OpenBCIWifiShieldBoard::find_wifi_shield ()
             {
                 std::string response ((const char *)b);
                 safe_logger (spdlog::level::trace, "Recived package {}", b);
-                std::regex rgx ("LOCATION: http://([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)");
+                std::regex rgx ("LOCATION: http://([0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+)");
                 std::smatch matches;
                 if (std::regex_search (response, matches, rgx) == true)
                 {


### PR DESCRIPTION
I get warnings from g++ about unrecognised escape sequence (`\.`) - I'm presuming the regular expression has been copied but without doubling the backslashes to get a literal backslash in the C-style string literal. 

For confirmation, I haven't tested this and I don't have any hardware I can use to test. I'm just going on the static code and what the build process has told me.