### PR TITLE
Allow using BoardIds as BoardShim argument

### DIFF
--- a/python-package/brainflow/board_shim.py
+++ b/python-package/brainflow/board_shim.py
@@ -15,7 +15,7 @@ from nptyping import NDArray, Float64
 from brainflow.exit_codes import BrainflowExitCodes
 
 
-class BoardIds (enum.Enum):
+class BoardIds (enum.IntEnum):
     """Enum to store all supported Board Ids"""
 
     PLAYBACK_FILE_BOARD = -3 #:

--- a/python-package/brainflow/board_shim.py
+++ b/python-package/brainflow/board_shim.py
@@ -41,7 +41,7 @@ class BoardIds (enum.IntEnum):
     FREEEEG32_BOARD = 17 #:
 
 
-class LogLevels (enum.Enum):
+class LogLevels (enum.IntEnum):
     """Enum to store all log levels supported by BrainFlow"""
 
     LEVEL_TRACE = 0 #:
@@ -53,7 +53,7 @@ class LogLevels (enum.Enum):
     LEVEL_OFF = 6 #:
 
 
-class IpProtocolType (enum.Enum):
+class IpProtocolType (enum.IntEnum):
     """Enum to store Ip Protocol types"""
 
     NONE = 0 #:

--- a/python-package/brainflow/data_filter.py
+++ b/python-package/brainflow/data_filter.py
@@ -15,7 +15,7 @@ from brainflow.board_shim import BrainFlowError, LogLevels
 from brainflow.exit_codes import BrainflowExitCodes
 
 
-class FilterTypes (enum.Enum):
+class FilterTypes (enum.IntEnum):
     """Enum to store all supported Filter Types"""
 
     BUTTERWORTH = 0 #:
@@ -23,7 +23,7 @@ class FilterTypes (enum.Enum):
     BESSEL = 2 #:
 
 
-class AggOperations (enum.Enum):
+class AggOperations (enum.IntEnum):
     """Enum to store all supported aggregation operations"""
 
     MEAN = 0 #:
@@ -31,7 +31,7 @@ class AggOperations (enum.Enum):
     EACH = 2 #:
 
 
-class WindowFunctions (enum.Enum):
+class WindowFunctions (enum.IntEnum):
     """Enum to store all supported window functions"""
 
     NO_WINDOW = 0 #:
@@ -40,7 +40,7 @@ class WindowFunctions (enum.Enum):
     BLACKMAN_HARRIS = 3 #:
 
 
-class DetrendOperations (enum.Enum):
+class DetrendOperations (enum.IntEnum):
     """Enum to store all supported detrend options"""
 
     NONE = 0 #:

--- a/python-package/brainflow/exit_codes.py
+++ b/python-package/brainflow/exit_codes.py
@@ -1,7 +1,7 @@
 import enum
 
 
-class BrainflowExitCodes (enum.Enum):
+class BrainflowExitCodes (enum.IntEnum):
     """Enum to store all possible exit codes"""
 
     STATUS_OK = 0

--- a/python-package/brainflow/ml_model.py
+++ b/python-package/brainflow/ml_model.py
@@ -16,14 +16,14 @@ from brainflow.board_shim import BrainFlowError, LogLevels
 from brainflow.exit_codes import BrainflowExitCodes
 
 
-class BrainFlowMetrics (enum.Enum):
+class BrainFlowMetrics (enum.IntEnum):
     """Enum to store all supported metrics"""
 
     RELAXATION = 0 #:
     CONCENTRATION = 1 #:
 
 
-class BrainFlowClassifiers (enum.Enum):
+class BrainFlowClassifiers (enum.IntEnum):
     """Enum to store all supported classifiers"""
 
     REGRESSION = 0 #:


### PR DESCRIPTION
BoardIds used to be a enum.Enum, not enum.IntEnum, which caused problems when passing the ID to native code. Making it IntEnum instead makes the following code work, which is the 'right' code as hinted by documentation:

```python
board = BoardShim(BoardIds.SYNTHETIC_BOARD, params)
```