### PR TITLE
Added ARM little endian to oscpp library

### DIFF
--- a/third_party/oscpp/include/oscpp/detail/endian.hpp
+++ b/third_party/oscpp/include/oscpp/detail/endian.hpp
@@ -71,7 +71,7 @@
     defined(__ia64__) || defined(_M_IX86) || defined(_M_IA64) ||     \
     defined(_M_ALPHA) || defined(__amd64) || defined(__amd64__) ||   \
     defined(_M_AMD64) || defined(__x86_64) || defined(__x86_64__) || \
-    defined(_M_X64) || defined(__bfin__)
+    defined(_M_X64) || defined(__bfin__) || defined(__arm__)
 
 #    define OSCPP_LITTLE_ENDIAN
 #    define OSCPP_BYTE_ORDER OSCPP_BYTE_ORDER_LITTLE_ENDIAN


### PR DESCRIPTION
This will allow compiling and building oscpp library in ARM based processors. In a majority of cases ARM is little endian.

OSCPP wasn't able to find the correct endian type on a alpine docker image on a raspberry pi 4 and I was getting this error:
`The file oscpp/endian.hpp needs to be set up for your CPU type docker`

I see that there was recent work on the Dockerfile and if you want to I can clean up my alpine Dockerfile and submit that as well. See: https://github.com/p-riebs/brainflow/blob/alpine_dockerfile/Docker/alpine/Dockerfile