### PR TITLE
Fix FFT on power-of-two data

### DIFF
--- a/src/data_handler/data_handler.cpp
+++ b/src/data_handler/data_handler.cpp
@@ -954,7 +954,7 @@ int get_psd_welch (double *data, int data_len, int nfft, int overlap, int sampli
     {
         output_ampl[i] = 0.0;
     }
-    for (int pos = 0; (pos + nfft) < data_len; pos += (nfft - overlap), counter++)
+    for (int pos = 0; (pos + nfft) <= data_len; pos += (nfft - overlap), counter++)
     {
         int res = get_psd (data + pos, nfft, sampling_rate, window_function, ampls, output_freq);
         if (res != (int)BrainFlowExitCodes::STATUS_OK)


### PR DESCRIPTION
nfft = 2^n requires at least 2^n + 1 pieces of data, while 2^n would suffice