### PR TITLE
rm accord as a dependency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,8 +134,6 @@ jobs:
         VERSION: ${{ github.event.inputs.version }}
     - name: Prepare Nuget Package
       run: |
-        nuget install Accord -OutputDirectory $env:GITHUB_WORKSPACE\csharp-package\brainflow\packages
-        nuget install Accord.Math -OutputDirectory $env:GITHUB_WORKSPACE\csharp-package\brainflow\packages
         Copy-Item "$env:GITHUB_WORKSPACE\linux\*" -Destination "$env:GITHUB_WORKSPACE\csharp-package\brainflow\brainflow\lib" -Recurse -Force -Filter *.*
         Copy-Item "$env:GITHUB_WORKSPACE\macos\*" -Destination "$env:GITHUB_WORKSPACE\csharp-package\brainflow\brainflow\lib" -Recurse -Force -Filter *.*
         Copy-Item "$env:GITHUB_WORKSPACE\win64\*" -Destination "$env:GITHUB_WORKSPACE\csharp-package\brainflow\brainflow\lib" -Recurse -Force -Filter *.*

--- a/.github/workflows/run_windows.yml
+++ b/.github/workflows/run_windows.yml
@@ -42,11 +42,6 @@ jobs:
         cmake -DWARNINGS_AS_ERRORS=ON -G "Visual Studio 16 2019" -A x64 -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_INSTALL_PREFIX=..\installed64\ ..
         cmake --build . --target install --config Release -j 2 --parallel 2
       shell: cmd
-    - name: Nuget
-      run: |
-        nuget install Accord -OutputDirectory %GITHUB_WORKSPACE%\csharp-package\brainflow\packages
-        nuget install Accord.Math -OutputDirectory %GITHUB_WORKSPACE%\csharp-package\brainflow\packages
-      shell: cmd
     - name: C# build
       run: |
         cd %GITHUB_WORKSPACE%\csharp-package\brainflow

--- a/csharp-package/brainflow/band_power/band_power.cs
+++ b/csharp-package/brainflow/band_power/band_power.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Numerics;
 using brainflow;
 
-using Accord.Math;
 
 namespace test
 {

--- a/csharp-package/brainflow/band_power/band_power.csproj
+++ b/csharp-package/brainflow/band_power/band_power.csproj
@@ -56,15 +56,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -89,13 +80,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp-package/brainflow/band_power_all/band_power_all.cs
+++ b/csharp-package/brainflow/band_power_all/band_power_all.cs
@@ -2,7 +2,6 @@
 using System.Numerics;
 using brainflow;
 
-using Accord.Math;
 
 namespace test
 {

--- a/csharp-package/brainflow/band_power_all/band_power_all.csproj
+++ b/csharp-package/brainflow/band_power_all/band_power_all.csproj
@@ -56,15 +56,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -89,13 +80,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp-package/brainflow/brainflow/board_controller_library.cs
+++ b/csharp-package/brainflow/brainflow/board_controller_library.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
+
 namespace brainflow
 {
     public enum LogLevels

--- a/csharp-package/brainflow/brainflow/board_shim.cs
+++ b/csharp-package/brainflow/brainflow/board_shim.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Accord.Math;
 
 
 namespace brainflow

--- a/csharp-package/brainflow/brainflow/brainflow.csproj
+++ b/csharp-package/brainflow/brainflow/brainflow.csproj
@@ -94,15 +94,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -122,6 +113,7 @@
     <Compile Include="brainflow_exception.cs" />
     <Compile Include="data_filter.cs" />
     <Compile Include="data_handler_library.cs" />
+    <Compile Include="matrix_helpers.cs" />
     <Compile Include="ml_model.cs" />
     <Compile Include="ml_module_library.cs" />
     <Compile Include="platform_helper.cs" />
@@ -129,7 +121,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">
@@ -147,13 +138,6 @@
     <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp-package/brainflow/brainflow/brainflow_exception.cs
+++ b/csharp-package/brainflow/brainflow/brainflow_exception.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+
 namespace brainflow
 {
     /// <summary>

--- a/csharp-package/brainflow/brainflow/brainflow_input_params.cs
+++ b/csharp-package/brainflow/brainflow/brainflow_input_params.cs
@@ -4,6 +4,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
 using System.Text;
 
+
 namespace brainflow
 {
     public enum IpProtocolType

--- a/csharp-package/brainflow/brainflow/brainflow_model_params.cs
+++ b/csharp-package/brainflow/brainflow/brainflow_model_params.cs
@@ -4,6 +4,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
 using System.Text;
 
+
 namespace brainflow
 {
     /// <summary>

--- a/csharp-package/brainflow/brainflow/data_filter.cs
+++ b/csharp-package/brainflow/brainflow/data_filter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Numerics;
 
-using Accord.Math;
 
 namespace brainflow
 {

--- a/csharp-package/brainflow/brainflow/matrix_helpers.cs
+++ b/csharp-package/brainflow/brainflow/matrix_helpers.cs
@@ -1,0 +1,475 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using brainflow;
+
+
+namespace brainflow
+{
+    /// <summary>
+    /// Matrix major order. The default is to use C-style Row-Major order.
+    /// </summary>
+    ///
+    public enum MatrixOrder
+    {
+        /// <summary>
+        /// Row-major order (C, C++, C#, SAS, Pascal, NumPy default).
+        /// </summary>
+        CRowMajor = 1,
+
+        /// <summary>
+        /// Column-major oder (Fotran, MATLAB, R).
+        /// </summary>
+        /// 
+        FortranColumnMajor = 0,
+
+        /// <summary>
+        /// Default (Row-Major, C/C++/C# order).
+        /// </summary>
+        /// 
+        Default = CRowMajor
+    }
+
+    public static class MatrixHelpers
+    {
+        /// <summary>
+        /// Gets a row vector from a matrix.
+        /// </summary>
+        /// 
+        public static T[] GetRow<T> (this T[][] m, int index, T[] result = null)
+        {
+            index = MatrixHelpers.index (index, m.Rows ());
+
+            if (result == null)
+            {
+                return (T[])m[index].Clone ();
+            }
+            else
+            {
+                m[index].CopyTo (result, 0);
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Gets a row vector from a matrix.
+        /// </summary>
+        ///
+        public static T[] GetRow<T> (this T[,] m, int index, T[] result = null)
+        {
+            if (result == null)
+            {
+                result = new T[m.GetLength (1)];
+            }
+
+            index = MatrixHelpers.index (index, m.Rows ());
+            for (int i = 0; i < result.Length; i++)
+            {
+                result[i] = m[index, i];
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the number of rows in a vector.
+        /// </summary>
+        /// 
+        /// <typeparam name="T">The type of the elements in the column vector.</typeparam>
+        /// <param name="vector">The vector whose number of rows must be computed.</param>
+        /// 
+        /// <returns>The number of rows in the column vector.</returns>
+        /// 
+        public static int Rows<T> (this T[] vector)
+        {
+            return vector.Length;
+        }
+
+        /// <summary>
+        /// Gets the number of rows in a multidimensional matrix.
+        /// </summary>
+        /// 
+        /// <typeparam name="T">The type of the elements in the matrix.</typeparam>
+        /// <param name="matrix">The matrix whose number of rows must be computed.</param>
+        /// 
+        /// <returns>The number of rows in the matrix.</returns>
+        /// 
+        public static int Rows<T> (this T[,] matrix)
+        {
+            return matrix.GetLength (0);
+        }
+
+        /// <summary>
+        /// Gets the number of columns in a multidimensional matrix.
+        /// </summary>
+        /// 
+        /// <typeparam name="T">The type of the elements in the matrix.</typeparam>
+        /// <param name="matrix">The matrix whose number of columns must be computed.</param>
+        /// 
+        /// <returns>The number of columns in the matrix.</returns>
+        /// 
+        public static int Columns<T> (this T[,] matrix)
+        {
+            return matrix.GetLength (1);
+        }
+
+        /// <summary>
+        /// Gets the number of rows in a multidimensional matrix.
+        /// </summary>
+        /// 
+        /// <typeparam name="T">The type of the elements in the matrix.</typeparam>
+        /// <param name="matrix">The matrix whose number of rows must be computed.</param>
+        /// 
+        /// <returns>The number of rows in the matrix.</returns>
+        /// 
+        public static int Rows<T> (this T[,,] matrix)
+        {
+            return matrix.GetLength (0);
+        }
+
+        /// <summary>
+        /// Transforms a matrix into a single vector.
+        /// </summary>
+        /// 
+        /// <param name="matrix">A matrix.</param>
+        /// <param name="order">The direction to perform copying. Pass
+        ///   1 to perform a copy by reading the matrix in row-major order.
+        ///   Pass 0 to perform a copy in column-major copy. Default is 1 
+        ///   (row-major, c-style order).</param>
+        /// 
+        public static T[] Flatten<T> (this T[,] matrix, MatrixOrder order = MatrixOrder.Default)
+        {
+            return Reshape (matrix, order);
+        }
+
+        /// <summary>
+        /// Transforms a matrix into a single vector.
+        /// </summary>
+        /// 
+        /// <param name="matrix">A matrix.</param>
+        /// <param name="result">The vector where to store the copy.</param>
+        /// <param name="order">The direction to perform copying. Pass
+        ///   1 to perform a copy by reading the matrix in row-major order.
+        ///   Pass 0 to perform a copy in column-major copy. Default is 1 
+        ///   (row-major, c-style order).</param>
+        /// 
+        public static T[] Flatten<T> (this T[,] matrix, T[] result, MatrixOrder order = MatrixOrder.Default)
+        {
+            return Reshape (matrix, result, order);
+        }
+
+
+        /// <summary>
+        /// Transforms a jagged array matrix into a single vector.
+        /// </summary>
+        /// 
+        /// <param name="array">A jagged array.</param>
+        /// <param name="order">The direction to perform copying. Pass
+        ///   1 to perform a copy by reading the matrix in row-major order.
+        ///   Pass 0 to perform a copy in column-major copy. Default is 1 
+        ///   (row-major, c-style order).</param>
+        /// 
+        public static T[] Flatten<T> (this T[][] array, MatrixOrder order = MatrixOrder.Default)
+        {
+            return Reshape (array, order);
+        }
+
+        /// <summary>
+        /// Transforms a jagged array matrix into a single vector.
+        /// </summary>
+        /// 
+        /// <param name="array">A jagged array.</param>
+        /// <param name="result">The vector where to store the copy.</param>
+        /// <param name="order">The direction to perform copying. Pass
+        ///   1 to perform a copy by reading the matrix in row-major order.
+        ///   Pass 0 to perform a copy in column-major copy. Default is 1 
+        ///   (row-major, c-style order).</param>
+        /// 
+        public static T[] Flatten<T> (this T[][] array, T[] result, MatrixOrder order = MatrixOrder.Default)
+        {
+            return Reshape (array, result, order);
+        }
+
+        /// <summary>
+        /// Transforms a matrix into a single vector.
+        /// </summary>
+        /// 
+        /// <param name="matrix">A matrix.</param>
+        /// <param name="order">The direction to perform copying. Pass
+        ///   1 to perform a copy by reading the matrix in row-major order.
+        ///   Pass 0 to perform a copy in column-major copy. Default is 1 
+        ///   (row-major, c-style order).</param>
+        /// 
+        public static T[] Reshape<T> (this T[,] matrix, MatrixOrder order = MatrixOrder.Default)
+        {
+            int rows = matrix.GetLength (0);
+            int cols = matrix.GetLength (1);
+            return Reshape (matrix, new T[rows * cols], order);
+        }
+
+        /// <summary>
+        /// Transforms a matrix into a single vector.
+        /// </summary>
+        /// 
+        /// <param name="matrix">A matrix.</param>
+        /// <param name="result">The vector where to store the copy.</param>
+        /// <param name="order">The direction to perform copying. Pass
+        ///   1 to perform a copy by reading the matrix in row-major order.
+        ///   Pass 0 to perform a copy in column-major copy. Default is 1 
+        ///   (row-major, c-style order).</param>
+        /// 
+        public static T[] Reshape<T> (this T[,] matrix, T[] result, MatrixOrder order = MatrixOrder.Default)
+        {
+            int rows = matrix.GetLength (0);
+            int cols = matrix.GetLength (1);
+
+            if (order == MatrixOrder.CRowMajor)
+            {
+                int k = 0;
+                for (int j = 0; j < rows; j++)
+                    for (int i = 0; i < cols; i++)
+                        result[k++] = matrix[j, i];
+            }
+            else
+            {
+                int k = 0;
+                for (int i = 0; i < cols; i++)
+                    for (int j = 0; j < rows; j++)
+                        result[k++] = matrix[j, i];
+            }
+
+            return result;
+        }
+
+
+        /// <summary>
+        /// Transforms a jagged array matrix into a single vector.
+        /// </summary>
+        /// 
+        /// <param name="array">A jagged array.</param>
+        /// <param name="order">The direction to perform copying. Pass
+        ///   1 to perform a copy by reading the matrix in row-major order.
+        ///   Pass 0 to perform a copy in column-major copy. Default is 1 
+        ///   (row-major, c-style order).</param>
+        /// 
+        public static T[] Reshape<T> (this T[][] array, MatrixOrder order = MatrixOrder.Default)
+        {
+            int count = 0;
+            for (int i = 0; i < array.Length; i++)
+                count += array[i].Length;
+            return Reshape (array, new T[count], order);
+        }
+
+        /// <summary>
+        ///   Transforms a jagged array matrix into a single vector.
+        /// </summary>
+        /// 
+        /// <param name="array">A jagged array.</param>
+        /// <param name="result">The vector where to store the copy.</param>
+        /// <param name="order">The direction to perform copying. Pass
+        ///   1 to perform a copy by reading the matrix in row-major order.
+        ///   Pass 0 to perform a copy in column-major copy. Default is 1 
+        ///   (row-major, c-style order).</param>
+        /// 
+        public static T[] Reshape<T> (this T[][] array, T[] result, MatrixOrder order = MatrixOrder.Default)
+        {
+            if (order == MatrixOrder.CRowMajor)
+            {
+                int k = 0;
+                for (int j = 0; j < array.Length; j++)
+                    for (int i = 0; i < array[j].Length; i++)
+                        result[k++] = array[j][i];
+            }
+            else
+            {
+                int maxCols = 0;
+                for (int i = 0; i < array.Length; i++)
+                {
+                    if (array[i].Length > maxCols)
+                        maxCols = array[i].Length;
+                }
+
+                for (int i = 0, k = 0; i < maxCols; i++)
+                {
+                    for (int j = 0; j < array.Length; j++)
+                    {
+                        if (i < array[j].Length)
+                            result[k++] = array[j][i];
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Combines two vectors horizontally.
+        /// </summary>
+        /// 
+        public static T[] Concatenate<T> (this T[] a, params T[] b)
+        {
+            T[] r = new T[a.Length + b.Length];
+            for (int i = 0; i < a.Length; i++)
+                r[i] = a[i];
+            for (int i = 0; i < b.Length; i++)
+                r[i + a.Length] = b[i];
+
+            return r;
+        }
+
+        /// <summary>
+        /// Combines a vector and a element horizontally.
+        /// </summary>
+        /// 
+        public static T[] Concatenate<T> (this T[] vector, T element)
+        {
+            T[] r = new T[vector.Length + 1];
+            for (int i = 0; i < vector.Length; i++)
+                r[i] = vector[i];
+
+            r[vector.Length] = element;
+
+            return r;
+        }
+
+        /// <summary>
+        /// Combines a vector and a element horizontally.
+        /// </summary>
+        /// 
+        public static T[] Concatenate<T> (this T element, T[] vector)
+        {
+            T[] r = new T[vector.Length + 1];
+
+            r[0] = element;
+
+            for (int i = 0; i < vector.Length; i++)
+                r[i + 1] = vector[i];
+
+            return r;
+        }
+
+        /// <summary>
+        /// Combines two matrices horizontally.
+        /// </summary>
+        /// 
+        public static T[,] Concatenate<T> (this T[,] a, T[,] b)
+        {
+            return Concatenate (new[] { a, b });
+        }
+
+        /// <summary>
+        /// Combines two matrices horizontally.
+        /// </summary>
+        /// 
+        public static T[][] Concatenate<T> (this T[][] a, T[][] b)
+        {
+            return Concatenate (new[] { a, b });
+        }
+
+        /// <summary>
+        /// Combines a matrix and a vector horizontally.
+        /// </summary>
+        /// 
+        public static T[,] Concatenate<T> (params T[][,] matrices)
+        {
+            int rows = 0;
+            int cols = 0;
+
+            for (int i = 0; i < matrices.Length; i++)
+            {
+                cols += matrices[i].GetLength (1);
+                if (matrices[i].GetLength (0) > rows)
+                    rows = matrices[i].GetLength (0);
+            }
+
+            T[,] r = new T[rows, cols];
+
+
+            int c = 0;
+            for (int k = 0; k < matrices.Length; k++)
+            {
+                int currentRows = matrices[k].GetLength (0);
+                int currentCols = matrices[k].GetLength (1);
+
+                for (int j = 0; j < currentCols; j++)
+                {
+                    for (int i = 0; i < currentRows; i++)
+                    {
+                        r[i, c] = matrices[k][i, j];
+                    }
+                    c++;
+                }
+            }
+
+            return r;
+        }
+
+        /// <summary>
+        /// Combines a matrix and a vector horizontally.
+        /// </summary>
+        /// 
+        public static T[][] Concatenate<T> (params T[][][] matrices)
+        {
+            int rows = 0;
+            int cols = 0;
+
+            for (int i = 0; i < matrices.Length; i++)
+            {
+                cols += matrices[i][0].Length;
+                if (matrices[i].Length > rows)
+                    rows = matrices[i].Length;
+            }
+
+            T[][] r = new T[rows][];
+            for (int i = 0; i < r.Length; i++)
+                r[i] = new T[cols];
+
+
+            int c = 0;
+            for (int k = 0; k < matrices.Length; k++)
+            {
+                int currentRows = matrices[k].Length;
+                int currentCols = matrices[k][0].Length;
+
+                for (int j = 0; j < currentCols; j++)
+                {
+                    for (int i = 0; i < currentRows; i++)
+                    {
+                        r[i][c] = matrices[k][i][j];
+                    }
+                    c++;
+                }
+            }
+
+            return r;
+        }
+
+        /// <summary>
+        /// Combine vectors horizontally.
+        /// </summary>
+        /// 
+        public static T[] Concatenate<T> (this T[][] vectors)
+        {
+            int size = 0;
+            for (int i = 0; i < vectors.Length; i++)
+                size += vectors[i].Length;
+
+            T[] r = new T[size];
+
+            int c = 0;
+            for (int i = 0; i < vectors.Length; i++)
+                for (int j = 0; j < vectors[i].Length; j++)
+                    r[c++] = vectors[i][j];
+
+            return r;
+        }
+
+        private static int index (int end, int length)
+        {
+            if (end < 0)
+            {
+                end = length + end;
+            }
+            return end;
+        }
+    }
+}

--- a/csharp-package/brainflow/brainflow/ml_model.cs
+++ b/csharp-package/brainflow/brainflow/ml_model.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+
 namespace brainflow
 {
     public class MLModel

--- a/csharp-package/brainflow/brainflow/ml_module_library.cs
+++ b/csharp-package/brainflow/brainflow/ml_module_library.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
+
 namespace brainflow
 {
     public enum BrainFlowMetrics

--- a/csharp-package/brainflow/brainflow/packages.config
+++ b/csharp-package/brainflow/brainflow/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Accord" version="3.8.0" targetFramework="net45" />
-  <package id="Accord.Math" version="3.8.0" targetFramework="net45" />
-</packages>

--- a/csharp-package/brainflow/brainflow/platform_helper.cs
+++ b/csharp-package/brainflow/brainflow/platform_helper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+
 namespace brainflow
 {
     public enum LibraryEnvironment

--- a/csharp-package/brainflow/brainflow_get_data/brainflow_get_data.cs
+++ b/csharp-package/brainflow/brainflow_get_data/brainflow_get_data.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using brainflow;
 
-using Accord.Math;
 
 namespace test
 {

--- a/csharp-package/brainflow/brainflow_get_data/brainflow_get_data.csproj
+++ b/csharp-package/brainflow/brainflow_get_data/brainflow_get_data.csproj
@@ -56,15 +56,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -88,13 +79,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp-package/brainflow/denoising/denoising.cs
+++ b/csharp-package/brainflow/denoising/denoising.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using brainflow;
 
-using Accord.Math;
 
 namespace test
 {

--- a/csharp-package/brainflow/denoising/denoising.csproj
+++ b/csharp-package/brainflow/denoising/denoising.csproj
@@ -56,15 +56,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -88,13 +79,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp-package/brainflow/downsampling/downsampling.cs
+++ b/csharp-package/brainflow/downsampling/downsampling.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using brainflow;
 
-using Accord.Math;
 
 namespace test
 {

--- a/csharp-package/brainflow/downsampling/downsampling.csproj
+++ b/csharp-package/brainflow/downsampling/downsampling.csproj
@@ -56,15 +56,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -88,13 +79,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp-package/brainflow/eeg_metrics/eeg_metrics.cs
+++ b/csharp-package/brainflow/eeg_metrics/eeg_metrics.cs
@@ -2,7 +2,6 @@
 using System.Numerics;
 using brainflow;
 
-using Accord.Math;
 
 namespace test
 {

--- a/csharp-package/brainflow/eeg_metrics/eeg_metrics.csproj
+++ b/csharp-package/brainflow/eeg_metrics/eeg_metrics.csproj
@@ -56,15 +56,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -89,13 +80,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp-package/brainflow/eeg_metrics_ci/eeg_metrics_ci.cs
+++ b/csharp-package/brainflow/eeg_metrics_ci/eeg_metrics_ci.cs
@@ -2,7 +2,6 @@
 using System.Numerics;
 using brainflow;
 
-using Accord.Math;
 
 namespace test
 {

--- a/csharp-package/brainflow/eeg_metrics_ci/eeg_metrics_ci.csproj
+++ b/csharp-package/brainflow/eeg_metrics_ci/eeg_metrics_ci.csproj
@@ -56,15 +56,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -89,13 +80,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp-package/brainflow/markers/markers.csproj
+++ b/csharp-package/brainflow/markers/markers.csproj
@@ -56,15 +56,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -88,13 +79,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp-package/brainflow/serialization/serialization.cs
+++ b/csharp-package/brainflow/serialization/serialization.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using brainflow;
 
-using Accord.Math;
 
 namespace test
 {

--- a/csharp-package/brainflow/serialization/serialization.csproj
+++ b/csharp-package/brainflow/serialization/serialization.csproj
@@ -56,15 +56,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -88,13 +79,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp-package/brainflow/signal_filtering/signal_filtering.cs
+++ b/csharp-package/brainflow/signal_filtering/signal_filtering.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using brainflow;
 
-using Accord.Math;
 
 namespace test
 {

--- a/csharp-package/brainflow/signal_filtering/signal_filtering.csproj
+++ b/csharp-package/brainflow/signal_filtering/signal_filtering.csproj
@@ -56,15 +56,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -88,13 +79,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/csharp-package/brainflow/transforms/transforms.cs
+++ b/csharp-package/brainflow/transforms/transforms.cs
@@ -2,7 +2,6 @@
 using System.Numerics;
 using brainflow;
 
-using Accord.Math;
 
 namespace test
 {

--- a/csharp-package/brainflow/transforms/transforms.csproj
+++ b/csharp-package/brainflow/transforms/transforms.csproj
@@ -56,15 +56,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Accord, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.3.8.0\lib\net45\Accord.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.dll</HintPath>
-    </Reference>
-    <Reference Include="Accord.Math.Core, Version=3.8.0.0, Culture=neutral, PublicKeyToken=fa1a88e29555ccf7, processorArchitecture=MSIL">
-      <HintPath>..\packages\Accord.Math.3.8.0\lib\net45\Accord.Math.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -89,13 +80,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Accord.3.8.0\build\Accord.targets" Condition="Exists('..\packages\Accord.3.8.0\build\Accord.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Accord.3.8.0\build\Accord.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Accord.3.8.0\build\Accord.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

#142 

Other options I considered:

* keep accord, the only problem with it: a little more complicated setup process and it's archived
* use nd arrays as is, but there are no methods to access rows\cols. Row access is needed for signal processing methods and for users to get data for entire channel
* use jagged arrays, row access will work from the box but it will be a breaking change  and not easy to work with
* write own class for NDArrays and probably do the same for other bindings
* use https://github.com/SciSharp/NumSharp 

How its implemented here:

* accord removed
* it's a multidemsional array but I ported very small subset of accord extensions to work with matrixes directly into C# binding. Directly in brainflow we used just a few methods from Accord, and they should work as is right now even wo accord. But it still can break users code if they call other methods from Accord
