### PR TITLE
Upgrade JNA

### DIFF
--- a/java-package/brainflow/pom.xml
+++ b/java-package/brainflow/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
        <groupId>net.java.dev.jna</groupId>
        <artifactId>jna-platform</artifactId>
-       <version>4.5.1</version>
+       <version>5.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/java-package/brainflow/src/main/java/module-info.java
+++ b/java-package/brainflow/src/main/java/module-info.java
@@ -5,5 +5,5 @@ module brainflow
     requires transitive commons.lang3;
     requires transitive commons.math3;
     requires gson;
-    requires jna;
+    requires com.sun.jna;
 }


### PR DESCRIPTION
While working with android I noticed the JNA version used in brainflow is pretty old.

Here's a small PR to upgrade that version.