### PR TITLE
github workflows: only auto-upload on the main repository

### DIFF
--- a/.github/workflows/run_android.yml
+++ b/.github/workflows/run_android.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Install AWS CLI
       run: sudo -H python -m pip install awscli
     - name: Upload To AWS
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && github.repository == 'brainflow-dev/brainflow' }}
       run: |
         cd $GITHUB_WORKSPACE/tools
         aws s3 cp jniLibs.zip s3://brainflow/$GITHUB_SHA/

--- a/.github/workflows/run_unix.yml
+++ b/.github/workflows/run_unix.yml
@@ -252,14 +252,14 @@ jobs:
     - name: Install AWS CLI
       run: sudo -H python3 -m pip install awscli
     - name: Push Libraries Linux Docker
-      if: ${{ github.event_name == 'push' && matrix.os == 'ubuntu-18.04'}}
+      if: ${{ github.event_name == 'push' && matrix.os == 'ubuntu-18.04' && github.repository == 'brainflow-dev/brainflow' }}
       run: |
         aws s3 cp $GITHUB_WORKSPACE/installed_docker/lib/ s3://brainflow/$GITHUB_SHA/linux --recursive
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Push Libraries MacOS Dev
-      if: ${{ github.event_name == 'push' && matrix.os == 'macos-10.15'}}
+      if: ${{ github.event_name == 'push' && matrix.os == 'macos-10.15' && github.repository == 'brainflow-dev/brainflow' }}
       run: |
         aws s3 cp $GITHUB_WORKSPACE/installed/lib/ s3://brainflow/$GITHUB_SHA/macos_dev --recursive
       env:

--- a/.github/workflows/run_windows.yml
+++ b/.github/workflows/run_windows.yml
@@ -231,7 +231,7 @@ jobs:
         python -m pip install awscli
       shell: cmd
     - name: Upload x86 Libs to AWS
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && github.repository == 'brainflow-dev/brainflow' }}
       run: |
         aws s3 cp %GITHUB_WORKSPACE%\installed32\ s3://brainflow/%GITHUB_SHA%/win32 --recursive
       shell: cmd
@@ -239,7 +239,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     - name: Upload x64 Libs to AWS
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && github.repository == 'brainflow-dev/brainflow' }}
       run: |
         aws s3 cp %GITHUB_WORKSPACE%\installed64\ s3://brainflow/%GITHUB_SHA%/win64 --recursive
       shell: cmd


### PR DESCRIPTION
This change lets tests pass in development forks (like mine) that don't have aws secrets in them.