### PR TITLE
add workaround for libftdi++ 1.5 include path bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,11 @@ if (USE_LIBFTDI)
     if (LibFTDI1_FOUND)
         # this line could set up the directories if included before targets are defined
         #include ( ${LIBFTDI_USE_FILE} )
+
+        # this works around a bug in some installations of libftdi++ 1.5
+        # http://developer.intra2net.com/git/?p=libftdi;a=commit;h=cdb28383402d248dbc6062f4391b038375c52385
+        set (LIBFTDI_INCLUDE_DIRS ${LIBFTDI_INCLUDE_DIRS} ${LIBFTDI_INCLUDE_DIR}/../libftdi1)
+
         target_compile_definitions (${BOARD_CONTROLLER_NAME} PRIVATE ${LIBFTDI_DEFINITIONS} "USE_LIBFTDI")
         target_include_directories (${BOARD_CONTROLLER_NAME} PRIVATE ${LIBFTDI_INCLUDE_DIRS})
         target_link_directories (${BOARD_CONTROLLER_NAME} PRIVATE ${LIBFTDI_LIBRARY_DIRS})


### PR DESCRIPTION
this was one of the intermittent macosx issues.  it was caused by a homebrew update that i actually submitted.  the issue is present in the official libftdi 1.5 release, so may be on other packaging systems too.

https://github.com/Homebrew/homebrew-core/issues/71623