### PR TITLE
Enable optical connection for FreeEEG32 on Windows

### DIFF
--- a/src/board_controller/freeeeg32/freeeeg32.cpp
+++ b/src/board_controller/freeeeg32/freeeeg32.cpp
@@ -202,30 +202,19 @@ int FreeEEG32::open_port ()
 
 int FreeEEG32::set_port_settings ()
 {
-#ifdef _WIN32
-    // windows driver fails to set settings and in fact ignores them, no idea what drivers on others
-    // OSes do
-    int timeout_only = true;
-#else
-    int timeout_only = false;
-#endif
-    int res = serial->set_serial_port_settings (1000, timeout_only);
+    int res = serial->set_serial_port_settings (1000, false);
     if (res < 0)
     {
         safe_logger (spdlog::level::err, "Unable to set port settings, res is {}", res);
         return (int)BrainFlowExitCodes::SET_PORT_ERROR;
     }
-#ifndef _WIN32
-    // looks like stm driver on windows ignores all settings, no need to change them
     res = serial->set_custom_baudrate (921600);
     if (res < 0)
     {
         safe_logger (spdlog::level::err, "Unable to set custom baud rate, res is {}", res);
         return (int)BrainFlowExitCodes::SET_PORT_ERROR;
     }
-#endif
     safe_logger (spdlog::level::trace, "set port settings");
-
     return (int)BrainFlowExitCodes::STATUS_OK;
 }
 

--- a/src/board_controller/freeeeg32/freeeeg32.cpp
+++ b/src/board_controller/freeeeg32/freeeeg32.cpp
@@ -212,7 +212,12 @@ int FreeEEG32::set_port_settings ()
     if (res < 0)
     {
         safe_logger (spdlog::level::err, "Unable to set custom baud rate, res is {}", res);
+        #ifndef _WIN32
+        // Setting the baudrate may return an error on Windows for some serial drivers.
+        // We do not throw an exception, because it will still work with USB.
+        // Optical connection will fail, though.
         return (int)BrainFlowExitCodes::SET_PORT_ERROR;
+        #endif
     }
     safe_logger (spdlog::level::trace, "set port settings");
     return (int)BrainFlowExitCodes::STATUS_OK;

--- a/src/board_controller/freeeeg32/freeeeg32.cpp
+++ b/src/board_controller/freeeeg32/freeeeg32.cpp
@@ -212,12 +212,12 @@ int FreeEEG32::set_port_settings ()
     if (res < 0)
     {
         safe_logger (spdlog::level::err, "Unable to set custom baud rate, res is {}", res);
-        #ifndef _WIN32
+#ifndef _WIN32
         // Setting the baudrate may return an error on Windows for some serial drivers.
         // We do not throw an exception, because it will still work with USB.
         // Optical connection will fail, though.
         return (int)BrainFlowExitCodes::SET_PORT_ERROR;
-        #endif
+#endif
     }
     safe_logger (spdlog::level::trace, "set port settings");
     return (int)BrainFlowExitCodes::STATUS_OK;

--- a/src/board_controller/freeeeg32/freeeeg32.cpp
+++ b/src/board_controller/freeeeg32/freeeeg32.cpp
@@ -206,7 +206,9 @@ int FreeEEG32::set_port_settings ()
     if (res < 0)
     {
         safe_logger (spdlog::level::err, "Unable to set port settings, res is {}", res);
+#ifndef _WIN32
         return (int)BrainFlowExitCodes::SET_PORT_ERROR;
+#endif
     }
     res = serial->set_custom_baudrate (921600);
     if (res < 0)


### PR DESCRIPTION
The FreeEEG32 board supports both USB and optical connections. Unfortunately, the optical connection does not currently work on Windows (it works as expected on macOS). This is because the serial port settings are disabled for Windows. While a comment in the code indicates that the driver ignores those settings, I have found out that it is actually possible to set the baudrate to 921600 (at least on my system, using the [Silabs USB to UART driver](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers), which is required for the optical dongle).
