### PR TITLE
Add stateful filters to data_handler interface

### DIFF
--- a/.github/workflows/run_unix.yml
+++ b/.github/workflows/run_unix.yml
@@ -179,6 +179,8 @@ jobs:
         sudo -H python3 $GITHUB_WORKSPACE/tests/python/serialization.py
     - name: Filters Python
       run: sudo -H python3 $GITHUB_WORKSPACE/tests/python/signal_filtering.py
+    - name: Filters with state Python
+      run: sudo -H python3 $GITHUB_WORKSPACE/tests/python/signal_filtering_with_state.py
     - name: Transforms Python
       run: sudo -H python3 $GITHUB_WORKSPACE/tests/python/transforms.py
     - name: Downsampling Python

--- a/.github/workflows/run_unix.yml
+++ b/.github/workflows/run_unix.yml
@@ -91,6 +91,13 @@ jobs:
         cd build
         cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/installed ..
         make
+    - name: Build data_handler Test
+      run: |
+        cd $GITHUB_WORKSPACE/tests/cpp/data_handler
+        mkdir build
+        cd build
+        cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/installed ..
+        make
     - name: Build ML Demo Test
       run: |
         cd $GITHUB_WORKSPACE/tests/cpp/ml_demo
@@ -220,6 +227,18 @@ jobs:
       run: $GITHUB_WORKSPACE/tests/cpp/signal_processing_demo/build/band_power
       env:
         LD_LIBRARY_PATH: ${{ github.workspace }}/installed/lib
+    - name: Signal filtering with state Cpp
+      run: |
+        cd $GITHUB_WORKSPACE
+        sudo -H $GITHUB_WORKSPACE/tests/cpp/data_handler/build/signal_filtering_with_state
+      env:
+          LD_LIBRARY_PATH: ${{ github.workspace }}/installed/lib
+    - name: Signal filtering with state using C API Cpp
+      run: |
+        cd $GITHUB_WORKSPACE
+        sudo -H $GITHUB_WORKSPACE/tests/cpp/data_handler/build/signal_filtering_c_with_state
+      env:
+          LD_LIBRARY_PATH: ${{ github.workspace }}/installed/lib
     - name: Denoising Java
       run: |
         cd $GITHUB_WORKSPACE/java-package/brainflow

--- a/.github/workflows/run_windows.yml
+++ b/.github/workflows/run_windows.yml
@@ -178,6 +178,9 @@ jobs:
     - name: Filtering Python Test
       run: python %GITHUB_WORKSPACE%\tests\python\signal_filtering.py
       shell: cmd
+    - name: Filtering with state Python Test
+      run: python %GITHUB_WORKSPACE%\tests\python\signal_filtering_with_state.py
+      shell: cmd
     - name: Transforms Python Test
       run: python %GITHUB_WORKSPACE%\tests\python\transforms.py
       shell: cmd

--- a/.github/workflows/run_windows.yml
+++ b/.github/workflows/run_windows.yml
@@ -73,6 +73,13 @@ jobs:
         cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_PREFIX_PATH=%GITHUB_WORKSPACE%\installed64\ ..
         cmake --build . --config Release -j 2 --parallel 2
       shell: cmd
+    - name: Build Cpp data_handler Test x64
+      run: |
+        mkdir %GITHUB_WORKSPACE%\tests\cpp\data_handler\build
+        cd %GITHUB_WORKSPACE%\tests\cpp\data_handler\build
+        cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_SYSTEM_VERSION=8.1 -DCMAKE_PREFIX_PATH=%GITHUB_WORKSPACE%\installed64\ ..
+        cmake --build . --config Release -j 2 --parallel 2
+      shell: cmd
     - name: Build Cpp ML Test x64
       run: |
         mkdir %GITHUB_WORKSPACE%\tests\cpp\ml_demo\build
@@ -206,6 +213,12 @@ jobs:
       shell: cmd
     - name: Serialization Cpp Test
       run: .\tests\cpp\signal_processing_demo\build\Release\serialization.exe
+      shell: cmd
+    - name: Signal filtering with state Cpp Test
+      run: .\tests\cpp\data_handler\build\Release\signal_filtering_with_state.exe
+      shell: cmd
+    - name: Signal filtering with state using C API Cpp Test
+      run: .\tests\cpp\data_handler\build\Release\signal_filtering_with_state.exe
       shell: cmd
     # Tests for MLModule
     - name: EEG Metrics Python Test

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -55,6 +55,13 @@ jobs:
         cd build
         cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/installed -DCMAKE_BUILD_TYPE=Debug ..
         make
+    - name: Build Signal filtering with state Test
+      run: |
+        cd $GITHUB_WORKSPACE/tests/cpp/data_handler
+        mkdir build
+        cd build
+        cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/installed -DCMAKE_BUILD_TYPE=Debug ..
+        make
     - name: Install Valgrind
       run: |
         sudo -H apt-get update -y
@@ -153,5 +160,13 @@ jobs:
           LD_LIBRARY_PATH: $GITHUB_WORKSPACE/installed/lib
     - name: BandPower Cpp
       run: valgrind --error-exitcode=1 --track-origins=yes --leak-check=full $GITHUB_WORKSPACE/tests/cpp/signal_processing_demo/build/band_power
+      env:
+        LD_LIBRARY_PATH: $GITHUB_WORKSPACE/installed/lib
+    - name: Signal filtering with state Cpp
+      run: valgrind --error-exitcode=1 --track-origins=yes --leak-check=full $GITHUB_WORKSPACE/tests/cpp/data_handler/build/signal_filtering_with_state
+      env:
+        LD_LIBRARY_PATH: $GITHUB_WORKSPACE/installed/lib
+    - name: Signal filtering with state using C API Cpp
+      run: valgrind --error-exitcode=1 --track-origins=yes --leak-check=full $GITHUB_WORKSPACE/tests/cpp/data_handler/build/signal_filtering_c_with_state
       env:
         LD_LIBRARY_PATH: $GITHUB_WORKSPACE/installed/lib

--- a/cpp-package/src/data_filter.cpp
+++ b/cpp-package/src/data_filter.cpp
@@ -3,7 +3,49 @@
 #include "brainflow_constants.h"
 #include "data_filter.h"
 #include "data_handler.h"
+#include "brainflow_filter.h"
 
+
+std::unique_ptr<brainflow_filter> DataFilter::create_lowpass_filter (int sampling_rate, double cutoff,
+    int order, int filter_type, double ripple)
+{
+    return ::create_lowpass_filter(sampling_rate, cutoff, order, filter_type, ripple);
+}
+
+std::unique_ptr<brainflow_filter> DataFilter::create_highpass_filter (int sampling_rate, double cutoff,
+    int order, int filter_type, double ripple)
+{
+    return ::create_highpass_filter(sampling_rate, cutoff, order, filter_type, ripple);
+}
+
+std::unique_ptr<brainflow_filter> DataFilter::create_bandpass_filter (int sampling_rate,
+    double center_freq, double band_width, int order, int filter_type, double ripple)
+{
+    return ::create_bandpass_filter(sampling_rate, center_freq, band_width, order, filter_type, ripple);
+}
+
+std::unique_ptr<brainflow_filter> DataFilter::create_bandstop_filter (int sampling_rate,
+    double center_freq, double band_width, int order, int filter_type, double ripple)
+{
+    return ::create_bandstop_filter(sampling_rate, center_freq, band_width, order, filter_type, ripple);
+}
+
+std::unique_ptr<brainflow_filter> DataFilter::create_environmental_noise_filter (
+    int sampling_rate, int noise_type)
+{
+    return ::create_environmental_noise_filter(sampling_rate, noise_type);
+}
+
+std::unique_ptr<brainflow_filter> DataFilter::create_rolling_filter (int period, int agg_operation)
+{
+    return ::create_rolling_filter(period, agg_operation);
+}
+
+std::unique_ptr<brainflow_filter> DataFilter::create_downsampling_filter (
+    int period, int agg_operation)
+{
+    return ::create_downsampling_filter(period, agg_operation);
+}
 
 void DataFilter::perform_lowpass (double *data, int data_len, int sampling_rate, double cutoff,
     int order, int filter_type, double ripple)

--- a/cpp-package/src/inc/data_filter.h
+++ b/cpp-package/src/inc/data_filter.h
@@ -3,6 +3,7 @@
 #include <complex>
 #include <utility>
 #include <vector>
+#include <memory>
 // include it here to allow user include only this single file
 #include "brainflow_array.h"
 #include "brainflow_constants.h"
@@ -24,6 +25,23 @@ public:
     static void set_log_level (int log_level);
     /// set log file
     static void set_log_file (std::string log_file);
+
+    static std::unique_ptr<brainflow_filter> create_lowpass_filter (int sampling_rate, double cutoff,
+        int order, int filter_type, double ripple);
+    static std::unique_ptr<brainflow_filter> create_highpass_filter (int sampling_rate, double cutoff,
+        int order, int filter_type, double ripple);
+    static std::unique_ptr<brainflow_filter> create_bandpass_filter (int sampling_rate, double center_freq,
+        double band_width, int order, int filter_type, double ripple);
+    static std::unique_ptr<brainflow_filter> create_bandstop_filter (int sampling_rate, double center_freq,
+        double band_width, int order, int filter_type, double ripple);
+    /// create notch filter to remove env noise
+    static std::unique_ptr<brainflow_filter> create_environmental_noise_filter (
+        int sampling_rate, int noise_type);
+    /// create moving average or moving median filter
+    static std::unique_ptr<brainflow_filter> create_rolling_filter (int period, int agg_operation);
+    /// create data downsampling, it just aggregates several data points
+    static std::unique_ptr<brainflow_filter> create_downsampling_filter (
+        int period, int agg_operation);
 
     /// perform low pass filter in-place
     static void perform_lowpass (double *data, int data_len, int sampling_rate, double cutoff,

--- a/cpp-package/src/inc/data_filter.h
+++ b/cpp-package/src/inc/data_filter.h
@@ -10,6 +10,7 @@
 #include "brainflow_exception.h"
 #include "data_handler.h"
 
+class brainflow_filter;
 
 /// DataFilter class to perform signal processing
 class DataFilter

--- a/src/data_handler/brainflow_filter.cpp
+++ b/src/data_handler/brainflow_filter.cpp
@@ -1,0 +1,547 @@
+#include "brainflow_filter.h"
+#include "brainflow_constants.h"
+#include "brainflow_exception.h"
+#include "data_handler.h"
+#include "downsample_operators.h"
+#include "rolling_filter.h"
+
+#include "DspFilters/Dsp.h"
+
+#include "spdlog/spdlog.h"
+
+#define LOGGER_NAME "data_logger"
+#define MAX_FILTER_ORDER 8
+
+extern std::shared_ptr<spdlog::logger> data_logger;
+
+brainflow_filter::~brainflow_filter ()
+{
+}
+
+class brainflow_dsp_filter_base : public brainflow_filter
+{
+public:
+    brainflow_dsp_filter_base () : brainflow_filter {} {};
+    ~brainflow_dsp_filter_base () {};
+
+    virtual void setParams (const Dsp::Params &parameters) = 0;
+};
+
+template <typename FILTER_TYPE>
+class brainflow_dsp_filter : public brainflow_dsp_filter_base
+{
+public:
+    brainflow_dsp_filter () : brainflow_dsp_filter_base {}, filter {} {};
+    ~brainflow_dsp_filter () {};
+
+    int process (double *data, int data_len) override
+    {
+        double *filter_data[1] = {data};
+
+        filter.process (data_len, filter_data);
+        return data_len;
+    }
+    void setParams (const Dsp::Params &parameters) override
+    {
+        filter.setParams (parameters);
+    }
+
+private:
+    FILTER_TYPE filter;
+};
+
+template <typename FILTER_TYPE>
+class brainflow_rolling_filter : public brainflow_filter
+{
+public:
+    brainflow_rolling_filter (int period) : brainflow_filter {}, filter {period} {};
+    ~brainflow_rolling_filter () {};
+
+    int process (double *data, int data_len) override
+    {
+        for (int i = 0; i < data_len; i++)
+        {
+            filter.add_data (data[i]);
+            data[i] = filter.get_value ();
+        }
+        return data_len;
+    }
+
+private:
+    FILTER_TYPE filter;
+};
+
+class brainflow_unity_filter : public brainflow_filter
+{
+public:
+    brainflow_unity_filter (int period) : brainflow_filter {} {};
+    ~brainflow_unity_filter () {};
+
+    int process (double *data, int data_len) override
+    {
+        return data_len;
+    }
+};
+
+template <typename FILTER_TYPE>
+class brainflow_downsampling_filter : public brainflow_filter
+{
+public:
+    brainflow_downsampling_filter (int period)
+        : brainflow_filter {}, filter {period}, period {period}, sample_count {0} {};
+    ~brainflow_downsampling_filter () {};
+
+    int process (double *data, int data_len) override
+    {
+        int out_i = 0;
+        for (int i = 0; i < data_len; i++)
+        {
+            filter.add_data (data[i]);
+            if (++sample_count == period)
+            {
+                sample_count = 0;
+                data[out_i] = filter.get_value ();
+                ++out_i;
+            }
+        }
+        return out_i;
+    }
+
+private:
+    FILTER_TYPE filter;
+    const int period;
+    int sample_count;
+};
+
+std::unique_ptr<brainflow_filter> create_lowpass_filter (
+    int sampling_rate, double cutoff, int order, int filter_type, double ripple)
+{
+    if ((order < 1) || (order > MAX_FILTER_ORDER))
+    {
+        data_logger->error ("Order must be from 1-8. Order:{}", order);
+        throw BrainFlowException {"Order must be from 1-8",
+            static_cast<int> (BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR)};
+    }
+
+    brainflow_dsp_filter_base *filter = nullptr;
+
+    switch (static_cast<FilterTypes> (filter_type))
+    {
+        case FilterTypes::BUTTERWORTH:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::Butterworth::Design::LowPass<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        case FilterTypes::CHEBYSHEV_TYPE_1:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::ChebyshevI::Design::LowPass<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        case FilterTypes::BESSEL:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::Bessel::Design::LowPass<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        default:
+            data_logger->error ("Filter type {} is Invalid", filter_type);
+            throw BrainFlowException {"Invalid filter type",
+                static_cast<int> (BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR)};
+    }
+
+    Dsp::Params params;
+    params[0] = sampling_rate;
+    params[1] = order;
+    params[2] = cutoff;
+    if (filter_type == (int)FilterTypes::CHEBYSHEV_TYPE_1)
+    {
+        params[3] = ripple;
+    }
+    filter->setParams (params);
+
+    return std::unique_ptr<brainflow_filter> {filter};
+}
+
+std::unique_ptr<brainflow_filter> create_highpass_filter (
+    int sampling_rate, double cutoff, int order, int filter_type, double ripple)
+{
+    if ((order < 1) || (order > MAX_FILTER_ORDER))
+    {
+        data_logger->error ("Order must be from 1-8. Order:{}", order);
+        throw BrainFlowException {"Order must be from 1-8",
+            static_cast<int> (BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR)};
+    }
+
+    brainflow_dsp_filter_base *filter = nullptr;
+
+    switch (static_cast<FilterTypes> (filter_type))
+    {
+        case FilterTypes::BUTTERWORTH:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::Butterworth::Design::HighPass<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        case FilterTypes::CHEBYSHEV_TYPE_1:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::ChebyshevI::Design::HighPass<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        case FilterTypes::BESSEL:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::Bessel::Design::HighPass<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        default:
+            data_logger->error ("Filter type {} is Invalid", filter_type);
+            throw BrainFlowException {"Invalid filter type",
+                static_cast<int> (BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR)};
+    }
+    Dsp::Params params;
+    params[0] = sampling_rate;
+    params[1] = order;
+    params[2] = cutoff;
+    if (filter_type == (int)FilterTypes::CHEBYSHEV_TYPE_1)
+    {
+        params[3] = ripple;
+    }
+    filter->setParams (params);
+
+    return std::unique_ptr<brainflow_filter> {filter};
+}
+
+std::unique_ptr<brainflow_filter> create_bandpass_filter (int sampling_rate, double center_freq,
+    double band_width, int order, int filter_type, double ripple)
+{
+    if ((order < 1) || (order > MAX_FILTER_ORDER))
+    {
+        data_logger->error ("Order must be from 1-8. Order:{}", order);
+        throw BrainFlowException {"Order must be from 1-8",
+            static_cast<int> (BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR)};
+    }
+
+    brainflow_dsp_filter_base *filter = nullptr;
+
+    switch (static_cast<FilterTypes> (filter_type))
+    {
+        case FilterTypes::BUTTERWORTH:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::Butterworth::Design::BandPass<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        case FilterTypes::CHEBYSHEV_TYPE_1:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::ChebyshevI::Design::BandPass<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        case FilterTypes::BESSEL:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::Bessel::Design::BandPass<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        default:
+            data_logger->error ("Filter type {} is Invalid. ", filter_type);
+            throw BrainFlowException {"Invalid filter type",
+                static_cast<int> (BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR)};
+    }
+
+    Dsp::Params params;
+    params[0] = sampling_rate;
+    params[1] = order;
+    params[2] = center_freq;
+    params[3] = band_width;
+    if (filter_type == (int)FilterTypes::CHEBYSHEV_TYPE_1)
+    {
+        params[4] = ripple;
+    }
+    filter->setParams (params);
+
+    return std::unique_ptr<brainflow_filter> {filter};
+}
+
+std::unique_ptr<brainflow_filter> create_bandstop_filter (int sampling_rate, double center_freq,
+    double band_width, int order, int filter_type, double ripple)
+{
+    if ((order < 1) || (order > MAX_FILTER_ORDER))
+    {
+        data_logger->error ("Order must be from 1-8. Order:{}", order);
+        throw BrainFlowException {"Order must be from 1-8",
+            static_cast<int> (BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR)};
+    }
+
+    brainflow_dsp_filter_base *filter = nullptr;
+
+    switch (static_cast<FilterTypes> (filter_type))
+    {
+        case FilterTypes::BUTTERWORTH:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::Butterworth::Design::BandStop<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        case FilterTypes::CHEBYSHEV_TYPE_1:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::ChebyshevI::Design::BandStop<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        case FilterTypes::BESSEL:
+            filter = new brainflow_dsp_filter<
+                Dsp::FilterDesign<Dsp::Bessel::Design::BandStop<MAX_FILTER_ORDER>, 1>> ();
+            break;
+        default:
+            data_logger->error ("Filter type {} is Invalid", filter_type);
+            throw BrainFlowException {"Invalid filter type",
+                static_cast<int> (BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR)};
+    }
+
+    Dsp::Params params;
+    params[0] = sampling_rate;
+    params[1] = order;
+    params[2] = center_freq;
+    params[3] = band_width;
+    if (filter_type == (int)FilterTypes::CHEBYSHEV_TYPE_1)
+    {
+        params[4] = ripple;
+    }
+    filter->setParams (params);
+
+    return std::unique_ptr<brainflow_filter> {filter};
+}
+
+std::unique_ptr<brainflow_filter> create_environmental_noise_filter (
+    int sampling_rate, int noise_type)
+{
+    brainflow_filter *filter_out = nullptr;
+    if (sampling_rate < 1)
+    {
+        throw BrainFlowException {
+            "Invalid sample rate", static_cast<int> (BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR)};
+    }
+
+    int res = static_cast<int> (BrainFlowExitCodes::STATUS_OK);
+
+    switch (static_cast<NoiseTypes> (noise_type))
+    {
+        case NoiseTypes::FIFTY:
+            res = create_bandstop (&filter_out, sampling_rate, 50.0, 4.0, 4,
+                static_cast<int> (FilterTypes::BUTTERWORTH), 0.0);
+            break;
+        case NoiseTypes::SIXTY:
+            res = create_bandstop (&filter_out, sampling_rate, 60.0, 4.0, 4,
+                static_cast<int> (FilterTypes::BUTTERWORTH), 0.0);
+            break;
+        default:
+            data_logger->error ("Invalid noise type");
+            throw BrainFlowException {"Invalid noise type",
+                static_cast<int> (BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR)};
+    }
+    if (res != (int)BrainFlowExitCodes::STATUS_OK || !filter_out)
+    {
+        throw BrainFlowException {"Failed to create filter",
+            static_cast<int> (BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR)};
+    }
+
+    return std::unique_ptr<brainflow_filter> {filter_out};
+}
+
+std::unique_ptr<brainflow_filter> create_rolling_filter (int period, int agg_operation)
+{
+    if ((period <= 0))
+    {
+        data_logger->error ("Period must be >= 0. Period:{}", period);
+        throw BrainFlowException {
+            "Invalid period", (int)BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR};
+    }
+
+    brainflow_filter *filter = nullptr;
+
+    switch (static_cast<AggOperations> (agg_operation))
+    {
+        case AggOperations::MEAN:
+            filter = new brainflow_rolling_filter<RollingAverage<double>> (period);
+            break;
+        case AggOperations::MEDIAN:
+            filter = new brainflow_rolling_filter<RollingMedian<double>> (period);
+            break;
+        case AggOperations::EACH:
+            filter = new brainflow_unity_filter (period);
+            break;
+        default:
+            data_logger->error ("Invalid aggregate opteration:{}", agg_operation);
+            throw BrainFlowException {
+                "Invalid aggregate opteration", (int)BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR};
+    }
+
+    return std::unique_ptr<brainflow_filter> {filter};
+}
+
+std::unique_ptr<brainflow_filter> create_downsampling_filter (int period, int agg_operation)
+{
+    if ((period <= 0))
+    {
+        data_logger->error ("Period must be >= 0. Period:{}", period);
+        throw BrainFlowException {
+            "Invalid period", (int)BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR};
+    }
+
+    brainflow_filter *filter = nullptr;
+
+    // TODO: replace RollingAverage and RollingMedian with simple array buffer
+    switch (static_cast<AggOperations> (agg_operation))
+    {
+        case AggOperations::MEAN:
+            filter = new brainflow_downsampling_filter<RollingAverage<double>> (period);
+            break;
+        case AggOperations::MEDIAN:
+            filter = new brainflow_downsampling_filter<RollingMedian<double>> (period);
+            break;
+        default:
+            data_logger->error ("Invalid aggregate opteration:{}", agg_operation);
+            throw BrainFlowException {
+                "Invalid aggregate opteration", (int)BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR};
+    }
+
+    return std::unique_ptr<brainflow_filter> {filter};
+}
+
+int create_lowpass (brainflow_filter **filter_out, int sampling_rate, double cutoff, int order,
+    int filter_type, double ripple)
+{
+    int result = static_cast<int> (BrainFlowExitCodes::STATUS_OK);
+    try
+    {
+        auto filter = create_lowpass_filter (sampling_rate, cutoff, order, filter_type, ripple);
+        *filter_out = filter.release ();
+    }
+    catch (const BrainFlowException &e)
+    {
+        result = e.exit_code;
+    }
+    catch (...)
+    {
+        result = static_cast<int> (BrainFlowExitCodes::GENERAL_ERROR);
+    }
+    return result;
+}
+
+int create_highpass (brainflow_filter **filter_out, int sampling_rate, double cutoff, int order,
+    int filter_type, double ripple)
+{
+    int result = static_cast<int> (BrainFlowExitCodes::STATUS_OK);
+    try
+    {
+        auto filter = create_highpass_filter (sampling_rate, cutoff, order, filter_type, ripple);
+        *filter_out = filter.release ();
+    }
+    catch (const BrainFlowException &e)
+    {
+        result = e.exit_code;
+    }
+    catch (...)
+    {
+        result = static_cast<int> (BrainFlowExitCodes::GENERAL_ERROR);
+    }
+    return result;
+}
+
+int create_bandpass (brainflow_filter **filter_out, int sampling_rate, double center_freq,
+    double band_width, int order, int filter_type, double ripple)
+{
+    int result = static_cast<int> (BrainFlowExitCodes::STATUS_OK);
+    try
+    {
+        auto filter = create_bandpass_filter (
+            sampling_rate, center_freq, band_width, order, filter_type, ripple);
+        *filter_out = filter.release ();
+    }
+    catch (const BrainFlowException &e)
+    {
+        result = e.exit_code;
+    }
+    catch (...)
+    {
+        result = static_cast<int> (BrainFlowExitCodes::GENERAL_ERROR);
+    }
+    return result;
+}
+
+int create_bandstop (brainflow_filter **filter_out, int sampling_rate, double center_freq,
+    double band_width, int order, int filter_type, double ripple)
+{
+    int result = static_cast<int> (BrainFlowExitCodes::STATUS_OK);
+    try
+    {
+        auto filter = create_bandstop_filter (
+            sampling_rate, center_freq, band_width, order, filter_type, ripple);
+        *filter_out = filter.release ();
+    }
+    catch (const BrainFlowException &e)
+    {
+        result = e.exit_code;
+    }
+    catch (...)
+    {
+        result = static_cast<int> (BrainFlowExitCodes::GENERAL_ERROR);
+    }
+    return result;
+}
+
+int create_remove_environmental_noise (
+    brainflow_filter **filter_out, int sampling_rate, int noise_type)
+{
+    int result = static_cast<int> (BrainFlowExitCodes::STATUS_OK);
+    try
+    {
+        auto filter = create_environmental_noise_filter (sampling_rate, noise_type);
+        *filter_out = filter.release ();
+    }
+    catch (const BrainFlowException &e)
+    {
+        result = e.exit_code;
+    }
+    catch (...)
+    {
+        result = static_cast<int> (BrainFlowExitCodes::GENERAL_ERROR);
+    }
+    return result;
+}
+
+int create_rolling (brainflow_filter **filter_out, int period, int agg_operation)
+{
+    int result = static_cast<int> (BrainFlowExitCodes::STATUS_OK);
+    try
+    {
+        auto filter = create_rolling_filter (period, agg_operation);
+        *filter_out = filter.release ();
+    }
+    catch (const BrainFlowException &e)
+    {
+        result = e.exit_code;
+    }
+    catch (...)
+    {
+        result = static_cast<int> (BrainFlowExitCodes::GENERAL_ERROR);
+    }
+    return result;
+}
+
+int perform_filtering (brainflow_filter *filter, double *data, int data_len)
+{
+    int result = static_cast<int> (BrainFlowExitCodes::STATUS_OK);
+    try
+    {
+        filter->process (data, data_len);
+    }
+    catch (const BrainFlowException &e)
+    {
+        result = e.exit_code;
+    }
+    catch (...)
+    {
+        result = static_cast<int> (BrainFlowExitCodes::GENERAL_ERROR);
+    }
+    return result;
+}
+int destroy_filter (brainflow_filter **filter)
+{
+    int result = static_cast<int> (BrainFlowExitCodes::STATUS_OK);
+    try
+    {
+        std::unique_ptr<brainflow_filter> f {*filter};
+    }
+    catch (const BrainFlowException &e)
+    {
+        result = e.exit_code;
+    }
+    catch (...)
+    {
+        result = static_cast<int> (BrainFlowExitCodes::GENERAL_ERROR);
+    }
+    return result;
+}

--- a/src/data_handler/build.cmake
+++ b/src/data_handler/build.cmake
@@ -25,6 +25,7 @@ endif (CMAKE_SIZEOF_VOID_P EQUAL 8)
 
 SET (DATA_HANDLER_SRC
     ${CMAKE_HOME_DIRECTORY}/src/data_handler/data_handler.cpp
+    ${CMAKE_HOME_DIRECTORY}/src/data_handler/brainflow_filter.cpp
 )
 
 add_library (
@@ -100,6 +101,7 @@ endif (ANDROID)
 install (
     FILES
     ${CMAKE_HOME_DIRECTORY}/src/data_handler/inc/data_handler.h
+    ${CMAKE_HOME_DIRECTORY}/src/data_handler/inc/brainflow_filter.h
     DESTINATION inc
 )
 

--- a/src/data_handler/data_handler.cpp
+++ b/src/data_handler/data_handler.cpp
@@ -1,4 +1,3 @@
-#include <math.h>
 #include <sstream>
 #include <stdexcept>
 #include <stdint.h>

--- a/src/data_handler/inc/brainflow_filter.h
+++ b/src/data_handler/inc/brainflow_filter.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "shared_export.h"
+
+#ifdef __cplusplus
+
+#include <memory>
+
+class brainflow_filter
+{
+public:
+    brainflow_filter () {};
+    virtual ~brainflow_filter () = 0;
+    brainflow_filter (brainflow_filter &&) = delete;
+    brainflow_filter (const brainflow_filter &) = delete;
+    brainflow_filter &operator= (brainflow_filter &&) = delete;
+    brainflow_filter &operator= (const brainflow_filter &) = delete;
+
+    virtual int process (double *data, int data_len) = 0;
+};
+
+SHARED_EXPORT std::unique_ptr<brainflow_filter> create_lowpass_filter (
+    int sampling_rate, double cutoff, int order, int filter_type, double ripple);
+SHARED_EXPORT std::unique_ptr<brainflow_filter> create_highpass_filter (
+    int sampling_rate, double cutoff, int order, int filter_type, double ripple);
+SHARED_EXPORT std::unique_ptr<brainflow_filter> create_bandpass_filter (int sampling_rate,
+    double center_freq, double band_width, int order, int filter_type, double ripple);
+SHARED_EXPORT std::unique_ptr<brainflow_filter> create_bandstop_filter (int sampling_rate,
+    double center_freq, double band_width, int order, int filter_type, double ripple);
+SHARED_EXPORT std::unique_ptr<brainflow_filter> create_environmental_noise_filter (
+    int sampling_rate, int noise_type);
+SHARED_EXPORT std::unique_ptr<brainflow_filter> create_rolling_filter (
+    int period, int agg_operation);
+SHARED_EXPORT std::unique_ptr<brainflow_filter> create_downsampling_filter (
+    int period, int agg_operation);
+
+#endif

--- a/src/data_handler/inc/data_handler.h
+++ b/src/data_handler/inc/data_handler.h
@@ -3,11 +3,38 @@
 #include "shared_export.h"
 
 #ifdef __cplusplus
+class brainflow_filter;
+#else
+typedef struct brainflow_filter brainflow_filter;
+#endif
+
+#ifdef __cplusplus
 extern "C"
 {
 #endif
     // signal processing methods
     // ripple param is used only for chebyshev filter
+    SHARED_EXPORT int CALLING_CONVENTION create_lowpass (brainflow_filter **filter_out,
+        int sampling_rate, double cutoff, int order, int filter_type, double ripple);
+    SHARED_EXPORT int CALLING_CONVENTION create_highpass (brainflow_filter **filter_out,
+        int sampling_rate, double cutoff, int order, int filter_type, double ripple);
+    SHARED_EXPORT int CALLING_CONVENTION create_bandpass (brainflow_filter **filter_out,
+        int sampling_rate, double center_freq, double band_width, int order, int filter_type,
+        double ripple);
+    SHARED_EXPORT int CALLING_CONVENTION create_bandstop (brainflow_filter **filter_out,
+        int sampling_rate, double center_freq, double band_width, int order, int filter_type,
+        double ripple);
+    SHARED_EXPORT int CALLING_CONVENTION create_remove_environmental_noise (
+        brainflow_filter **filter_out, int sampling_rate, int noise_type);
+
+    SHARED_EXPORT int CALLING_CONVENTION create_rolling (
+        brainflow_filter **filter_out, int period, int agg_operation);
+
+    SHARED_EXPORT int CALLING_CONVENTION perform_filtering (
+        brainflow_filter *filter, double *data, int data_len);
+    SHARED_EXPORT int CALLING_CONVENTION destroy_filter (brainflow_filter **filter);
+
+
     SHARED_EXPORT int CALLING_CONVENTION perform_lowpass (double *data, int data_len,
         int sampling_rate, double cutoff, int order, int filter_type, double ripple);
     SHARED_EXPORT int CALLING_CONVENTION perform_highpass (double *data, int data_len,

--- a/src/data_handler/inc/data_handler.h
+++ b/src/data_handler/inc/data_handler.h
@@ -3,12 +3,6 @@
 #include "shared_export.h"
 
 #ifdef __cplusplus
-class brainflow_filter;
-#else
-typedef struct brainflow_filter brainflow_filter;
-#endif
-
-#ifdef __cplusplus
 extern "C"
 {
 #endif

--- a/src/data_handler/inc/data_handler.h
+++ b/src/data_handler/inc/data_handler.h
@@ -14,25 +14,23 @@ extern "C"
 #endif
     // signal processing methods
     // ripple param is used only for chebyshev filter
-    SHARED_EXPORT int CALLING_CONVENTION create_lowpass (brainflow_filter **filter_out,
-        int sampling_rate, double cutoff, int order, int filter_type, double ripple);
-    SHARED_EXPORT int CALLING_CONVENTION create_highpass (brainflow_filter **filter_out,
-        int sampling_rate, double cutoff, int order, int filter_type, double ripple);
-    SHARED_EXPORT int CALLING_CONVENTION create_bandpass (brainflow_filter **filter_out,
-        int sampling_rate, double center_freq, double band_width, int order, int filter_type,
-        double ripple);
-    SHARED_EXPORT int CALLING_CONVENTION create_bandstop (brainflow_filter **filter_out,
-        int sampling_rate, double center_freq, double band_width, int order, int filter_type,
-        double ripple);
+    SHARED_EXPORT int CALLING_CONVENTION create_lowpass (int *filter_id, int sampling_rate,
+        double cutoff, int order, int filter_type, double ripple);
+    SHARED_EXPORT int CALLING_CONVENTION create_highpass (int *filter_id, int sampling_rate,
+        double cutoff, int order, int filter_type, double ripple);
+    SHARED_EXPORT int CALLING_CONVENTION create_bandpass (int *filter_id, int sampling_rate,
+        double center_freq, double band_width, int order, int filter_type, double ripple);
+    SHARED_EXPORT int CALLING_CONVENTION create_bandstop (int *filter_id, int sampling_rate,
+        double center_freq, double band_width, int order, int filter_type, double ripple);
     SHARED_EXPORT int CALLING_CONVENTION create_remove_environmental_noise (
-        brainflow_filter **filter_out, int sampling_rate, int noise_type);
+        int *filter_id, int sampling_rate, int noise_type);
 
     SHARED_EXPORT int CALLING_CONVENTION create_rolling (
-        brainflow_filter **filter_out, int period, int agg_operation);
+        int *filter_id, int period, int agg_operation);
 
     SHARED_EXPORT int CALLING_CONVENTION perform_filtering (
-        brainflow_filter *filter, double *data, int data_len);
-    SHARED_EXPORT int CALLING_CONVENTION destroy_filter (brainflow_filter **filter);
+        int filter_id, double *data, int data_len);
+    SHARED_EXPORT int CALLING_CONVENTION destroy_filter (int filter_id);
 
 
     SHARED_EXPORT int CALLING_CONVENTION perform_lowpass (double *data, int data_len,

--- a/src/data_handler/inc/window_functions.h
+++ b/src/data_handler/inc/window_functions.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <algorithm>
-#include <vector>
+#include <cmath>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -19,7 +18,7 @@ inline void hanning_function (int window_len, double *wind)
 {
     for (int i = 0; i < window_len; i++)
     {
-        wind[i] = 0.5 - 0.5 * cos (2.0 * M_PI * i / window_len);
+        wind[i] = 0.5 - 0.5 * std::cos (2.0 * M_PI * i / window_len);
     }
 }
 
@@ -27,7 +26,7 @@ inline void hamming_function (int window_len, double *wind)
 {
     for (int i = 0; i < window_len; i++)
     {
-        wind[i] = 0.54 - 0.46 * cos (2.0 * M_PI * i / window_len);
+        wind[i] = 0.54 - 0.46 * std::cos (2.0 * M_PI * i / window_len);
     }
 }
 
@@ -35,8 +34,8 @@ inline void blackman_harris_function (int window_len, double *wind)
 {
     for (int i = 0; i < window_len; i++)
     {
-        wind[i] = 0.355768 - 0.487396 * cos (2.0 * M_PI * i / window_len) +
-            0.144232 * cos (4.0 * M_PI * i / window_len) -
-            0.012604 * cos (6.0 * M_PI * i / window_len);
+        wind[i] = 0.355768 - 0.487396 * std::cos (2.0 * M_PI * i / window_len) +
+            0.144232 * std::cos (4.0 * M_PI * i / window_len) -
+            0.012604 * std::cos (6.0 * M_PI * i / window_len);
     }
 }

--- a/tests/cpp/data_handler/CMakeLists.txt
+++ b/tests/cpp/data_handler/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required (VERSION 3.10)
+project (BRAINFLOW_DATA_HANDLER_TEST)
+
+set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_VERBOSE_MAKEFILE ON)
+
+macro (configure_msvc_runtime)
+    if (MSVC)
+        # Default to statically-linked runtime.
+        if ("${MSVC_RUNTIME}" STREQUAL "")
+            set (MSVC_RUNTIME "static")
+        endif ()
+        # Set compiler options.
+        set (variables
+            CMAKE_C_FLAGS_DEBUG
+            CMAKE_C_FLAGS_MINSIZEREL
+            CMAKE_C_FLAGS_RELEASE
+            CMAKE_C_FLAGS_RELWITHDEBINFO
+            CMAKE_CXX_FLAGS_DEBUG
+            CMAKE_CXX_FLAGS_MINSIZEREL
+            CMAKE_CXX_FLAGS_RELEASE
+            CMAKE_CXX_FLAGS_RELWITHDEBINFO
+        )
+        if (${MSVC_RUNTIME} STREQUAL "static")
+            message(STATUS
+                "MSVC -> forcing use of statically-linked runtime."
+            )
+            foreach (variable ${variables})
+                if (${variable} MATCHES "/MD")
+                    string (REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
+                endif ()
+            endforeach ()
+        else ()
+            message (STATUS
+                "MSVC -> forcing use of dynamically-linked runtime."
+            )
+            foreach (variable ${variables})
+                if (${variable} MATCHES "/MT")
+                    string (REGEX REPLACE "/MT" "/MD" ${variable} "${${variable}}")
+                endif ()
+            endforeach ()
+        endif ()
+    endif ()
+endmacro ()
+
+# link msvc runtime statically
+configure_msvc_runtime()
+
+find_package (
+    brainflow CONFIG REQUIRED
+)
+
+# Test signal processing with state same as all at once
+add_executable (
+    signal_filtering_with_state
+    src/signal_filtering.cpp
+)
+
+target_include_directories (
+    signal_filtering_with_state PUBLIC
+    ${brainflow_INCLUDE_DIRS}
+)
+
+target_link_libraries (
+    signal_filtering_with_state PUBLIC
+    # for some systems(ubuntu for example) order matters
+    ${BrainflowPath}
+    ${DataHandlerPath}
+    ${BoardControllerPath}
+)
+
+# Test signal processing with state, using C API, same as all at once
+add_executable (
+    signal_filtering_c_with_state
+    src/signal_filtering_c_api.cpp
+)
+
+target_include_directories (
+    signal_filtering_c_with_state PUBLIC
+    ${brainflow_INCLUDE_DIRS}
+)
+
+target_link_libraries (
+    signal_filtering_c_with_state PUBLIC
+    # for some systems(ubuntu for example) order matters
+    ${BrainflowPath}
+    ${DataHandlerPath}
+    ${BoardControllerPath}
+)

--- a/tests/cpp/data_handler/src/signal_filtering.cpp
+++ b/tests/cpp/data_handler/src/signal_filtering.cpp
@@ -61,7 +61,7 @@ int main (int argc, char *argv[])
             while (current_idx < data_length)
             {
                 const size_t batch_length = std::max (draw_length (rd), data_length - current_idx);
-                filter->process (data + current_idx, static_cast<int>(batch_length));
+                filter->process (data + current_idx, static_cast<int> (batch_length));
                 current_idx += batch_length;
             }
         };

--- a/tests/cpp/data_handler/src/signal_filtering.cpp
+++ b/tests/cpp/data_handler/src/signal_filtering.cpp
@@ -1,0 +1,161 @@
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <stdlib.h>
+#include <string>
+
+#ifdef _WIN32
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "board_shim.h"
+#include "brainflow_filter.h"
+#include "data_filter.h"
+
+using namespace std;
+
+
+int main (int argc, char *argv[])
+{
+    BoardShim::enable_dev_board_logger ();
+
+    struct BrainFlowInputParams params;
+    int res = 0;
+    int board_id = (int)BoardIds::SYNTHETIC_BOARD;
+    // use synthetic board for demo
+    BoardShim board {board_id, params};
+
+    try
+    {
+        board.prepare_session ();
+        board.start_stream ();
+
+#ifdef _WIN32
+        Sleep (5000);
+#else
+        sleep (5);
+#endif
+
+        board.stop_stream ();
+        BrainFlowArray<double, 2> data = board.get_board_data ();
+        board.release_session ();
+        std::cout << "Original data:" << std::endl << data << std::endl;
+
+        // apply filters
+        int sampling_rate = BoardShim::get_sampling_rate ((int)BoardIds::SYNTHETIC_BOARD);
+        std::vector<int> eeg_channels = BoardShim::get_eeg_channels (board_id);
+        const auto data_length = data.get_size (1);
+        auto batch_data = std::make_unique<double[]> (data_length);
+        auto state_data = std::make_unique<double[]> (data_length);
+
+        std::random_device rd;
+        std::uniform_int_distribution<size_t> draw_length {0, 1U + data_length / 5U};
+
+        auto stateful_filtering = [&draw_length, &rd] (std::unique_ptr<brainflow_filter> &filter,
+                                      double *data, const size_t data_length) {
+            size_t current_idx = 0;
+            while (current_idx < data_length)
+            {
+                const size_t batch_length = std::max (draw_length (rd), data_length - current_idx);
+                filter->process (data + current_idx, static_cast<int>(batch_length));
+                current_idx += batch_length;
+            }
+        };
+
+        for (int i = 0; i < eeg_channels.size (); i++)
+        {
+            std::copy_n (data.get_address (eeg_channels[i]), data_length, batch_data.get ());
+            std::copy_n (data.get_address (eeg_channels[i]), data_length, state_data.get ());
+            BrainFlowArray<double, 2> bf_orig {batch_data.get (), 1, data_length};
+            std::cout << "Original data:" << std::endl << bf_orig << std::endl;
+            switch (i)
+            {
+                // just for test and demo - apply different filters to different eeg channels
+                // signal filtering methods work in-place
+                case 0:
+                {
+                    DataFilter::perform_lowpass (batch_data.get (), data_length,
+                        BoardShim::get_sampling_rate (board_id), 30.0, 3,
+                        (int)FilterTypes::BUTTERWORTH, 0);
+                    std::unique_ptr<brainflow_filter> filter =
+                        DataFilter::create_lowpass_filter (BoardShim::get_sampling_rate (board_id),
+                            30.0, 3, (int)FilterTypes::BUTTERWORTH, 0);
+                    stateful_filtering (filter, state_data.get (), data_length);
+                }
+                break;
+                case 1:
+                {
+                    DataFilter::perform_highpass (batch_data.get (), data_length,
+                        BoardShim::get_sampling_rate (board_id), 5.0, 5,
+                        (int)FilterTypes::CHEBYSHEV_TYPE_1, 1);
+                    std::unique_ptr<brainflow_filter> filter =
+                        DataFilter::create_highpass_filter (BoardShim::get_sampling_rate (board_id),
+                            5.0, 5, (int)FilterTypes::CHEBYSHEV_TYPE_1, 1);
+                    stateful_filtering (filter, state_data.get (), data_length);
+                }
+                break;
+                case 2:
+                {
+                    DataFilter::perform_bandpass (batch_data.get (), data_length,
+                        BoardShim::get_sampling_rate (board_id), 15.0, 10.0, 3,
+                        (int)FilterTypes::BESSEL, 0);
+                    std::unique_ptr<brainflow_filter> filter =
+                        DataFilter::create_bandpass_filter (BoardShim::get_sampling_rate (board_id),
+                            15.0, 10.0, 3, (int)FilterTypes::BESSEL, 0);
+                    stateful_filtering (filter, state_data.get (), data_length);
+                }
+                break;
+                case 3:
+                {
+                    DataFilter::perform_bandstop (batch_data.get (), data_length,
+                        BoardShim::get_sampling_rate (board_id), 50.0, 4.0, 4,
+                        (int)FilterTypes::BUTTERWORTH, 0);
+                    std::unique_ptr<brainflow_filter> filter =
+                        DataFilter::create_bandstop_filter (BoardShim::get_sampling_rate (board_id),
+                            50.0, 4.0, 4, (int)FilterTypes::BUTTERWORTH, 0);
+                    stateful_filtering (filter, state_data.get (), data_length);
+                }
+                break;
+                default:
+                {
+                    DataFilter::remove_environmental_noise (batch_data.get (), data_length,
+                        BoardShim::get_sampling_rate (board_id), (int)NoiseTypes::FIFTY);
+                    std::unique_ptr<brainflow_filter> filter =
+                        DataFilter::create_environmental_noise_filter (
+                            BoardShim::get_sampling_rate (board_id), (int)NoiseTypes::FIFTY);
+                    stateful_filtering (filter, state_data.get (), data_length);
+                }
+                break;
+            }
+            BrainFlowArray<double, 2> bf_batch {batch_data.get (), 1, data_length};
+            std::cout << "Batch data:" << std::endl << bf_batch << std::endl;
+            double sum_abs_diff = 0.0;
+            for (int j = 0; j < data_length; ++j)
+            {
+                const auto abs_diff = std::abs (batch_data[j] - state_data[j]);
+                if (abs_diff > 1e-15)
+                {
+                    return 1;
+                }
+                sum_abs_diff += abs_diff;
+            }
+            std::cout << "abs diff sum:" << sum_abs_diff << std::endl;
+        }
+        std::cout << "Filtered data:" << std::endl << data << std::endl;
+    }
+    catch (const BrainFlowException &err)
+    {
+        BoardShim::log_message ((int)LogLevels::LEVEL_ERROR, err.what ());
+        res = err.exit_code;
+        if (board.is_prepared ())
+        {
+            board.release_session ();
+        }
+    }
+
+    return res;
+}

--- a/tests/cpp/data_handler/src/signal_filtering_c_api.cpp
+++ b/tests/cpp/data_handler/src/signal_filtering_c_api.cpp
@@ -1,0 +1,167 @@
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <stdlib.h>
+#include <string>
+
+#ifdef _WIN32
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "board_shim.h"
+#include "brainflow_filter.h"
+#include "data_filter.h"
+#include "data_handler.h"
+
+using namespace std;
+
+
+int main (int argc, char *argv[])
+{
+    BoardShim::enable_dev_board_logger ();
+
+    struct BrainFlowInputParams params;
+    int res = 0;
+    int board_id = (int)BoardIds::SYNTHETIC_BOARD;
+    // use synthetic board for demo
+    BoardShim board {board_id, params};
+
+    try
+    {
+        board.prepare_session ();
+        board.start_stream ();
+
+#ifdef _WIN32
+        Sleep (5000);
+#else
+        sleep (5);
+#endif
+
+        board.stop_stream ();
+        BrainFlowArray<double, 2> data = board.get_board_data ();
+        board.release_session ();
+        std::cout << "Original data:" << std::endl << data << std::endl;
+
+        // apply filters
+        int sampling_rate = BoardShim::get_sampling_rate ((int)BoardIds::SYNTHETIC_BOARD);
+        std::vector<int> eeg_channels = BoardShim::get_eeg_channels (board_id);
+        const auto data_length = data.get_size (1);
+        auto batch_data = std::make_unique<double[]> (data_length);
+        auto state_data = std::make_unique<double[]> (data_length);
+
+        std::random_device rd;
+        std::uniform_int_distribution<size_t> draw_length {0, 1U + data_length / 5U};
+
+        auto stateful_filtering = [&draw_length, &rd] (brainflow_filter *filter, double *data,
+                                      const size_t data_length) {
+            size_t current_idx = 0;
+            while (current_idx < data_length)
+            {
+                const size_t batch_length = std::max (draw_length (rd), data_length - current_idx);
+                ::perform_filtering (filter, data + current_idx, static_cast<int>(batch_length));
+                current_idx += batch_length;
+            }
+        };
+
+        for (int i = 0; i < eeg_channels.size (); i++)
+        {
+            std::copy_n (data.get_address (eeg_channels[i]), data_length, batch_data.get ());
+            std::copy_n (data.get_address (eeg_channels[i]), data_length, state_data.get ());
+            BrainFlowArray<double, 2> bf_orig {batch_data.get (), 1, data_length};
+            std::cout << "Original data:" << std::endl << bf_orig << std::endl;
+            switch (i)
+            {
+                // just for test and demo - apply different filters to different eeg channels
+                // signal filtering methods work in-place
+                case 0:
+                {
+                    DataFilter::perform_lowpass (batch_data.get (), data_length,
+                        BoardShim::get_sampling_rate (board_id), 30.0, 3,
+                        (int)FilterTypes::BUTTERWORTH, 0);
+                    brainflow_filter *filter;
+                    create_lowpass (&filter, BoardShim::get_sampling_rate (board_id), 30.0, 3,
+                        (int)FilterTypes::BUTTERWORTH, 0);
+                    stateful_filtering (filter, state_data.get (), data_length);
+                    ::destroy_filter (&filter);
+                }
+                break;
+                case 1:
+                {
+                    DataFilter::perform_highpass (batch_data.get (), data_length,
+                        BoardShim::get_sampling_rate (board_id), 5.0, 5,
+                        (int)FilterTypes::CHEBYSHEV_TYPE_1, 1);
+                    brainflow_filter *filter;
+                    ::create_highpass (&filter, BoardShim::get_sampling_rate (board_id), 5.0, 5,
+                        (int)FilterTypes::CHEBYSHEV_TYPE_1, 1);
+                    stateful_filtering (filter, state_data.get (), data_length);
+                    ::destroy_filter (&filter);
+                }
+                break;
+                case 2:
+                {
+                    DataFilter::perform_bandpass (batch_data.get (), data_length,
+                        BoardShim::get_sampling_rate (board_id), 15.0, 10.0, 3,
+                        (int)FilterTypes::BESSEL, 0);
+                    brainflow_filter *filter;
+                    ::create_bandpass (&filter, BoardShim::get_sampling_rate (board_id), 15.0, 10.0,
+                        3, (int)FilterTypes::BESSEL, 0);
+                    stateful_filtering (filter, state_data.get (), data_length);
+                    ::destroy_filter (&filter);
+                }
+                break;
+                case 3:
+                {
+                    DataFilter::perform_bandstop (batch_data.get (), data_length,
+                        BoardShim::get_sampling_rate (board_id), 50.0, 4.0, 4,
+                        (int)FilterTypes::BUTTERWORTH, 0);
+                    brainflow_filter *filter;
+                    ::create_bandstop (&filter, BoardShim::get_sampling_rate (board_id), 50.0, 4.0,
+                        4, (int)FilterTypes::BUTTERWORTH, 0);
+                    stateful_filtering (filter, state_data.get (), data_length);
+                    ::destroy_filter (&filter);
+                }
+                break;
+                default:
+                {
+                    DataFilter::remove_environmental_noise (batch_data.get (), data_length,
+                        BoardShim::get_sampling_rate (board_id), (int)NoiseTypes::FIFTY);
+                    brainflow_filter *filter;
+                    ::create_remove_environmental_noise (
+                        &filter, BoardShim::get_sampling_rate (board_id), (int)NoiseTypes::FIFTY);
+                    stateful_filtering (filter, state_data.get (), data_length);
+                    ::destroy_filter (&filter);
+                }
+                break;
+            }
+            BrainFlowArray<double, 2> bf_batch {batch_data.get (), 1, data_length};
+            std::cout << "Batch data:" << std::endl << bf_batch << std::endl;
+            double sum_abs_diff = 0.0;
+            for (int j = 0; j < data_length; ++j)
+            {
+                const auto abs_diff = std::abs (batch_data[j] - state_data[j]);
+                if (abs_diff > 1e-15)
+                {
+                    return 1;
+                }
+                sum_abs_diff += abs_diff;
+            }
+            std::cout << "abs diff sum:" << sum_abs_diff << std::endl;
+        }
+        std::cout << "Filtered data:" << std::endl << data << std::endl;
+    }
+    catch (const BrainFlowException &err)
+    {
+        BoardShim::log_message ((int)LogLevels::LEVEL_ERROR, err.what ());
+        res = err.exit_code;
+        if (board.is_prepared ())
+        {
+            board.release_session ();
+        }
+    }
+
+    return res;
+}

--- a/tests/cpp/data_handler/src/signal_filtering_c_api.cpp
+++ b/tests/cpp/data_handler/src/signal_filtering_c_api.cpp
@@ -56,13 +56,14 @@ int main (int argc, char *argv[])
         std::random_device rd;
         std::uniform_int_distribution<size_t> draw_length {0, 1U + data_length / 5U};
 
-        auto stateful_filtering = [&draw_length, &rd] (brainflow_filter *filter, double *data,
-                                      const size_t data_length) {
+        auto stateful_filtering = [&draw_length, &rd] (
+                                      int filter_id, double *data, const size_t data_length) {
             size_t current_idx = 0;
             while (current_idx < data_length)
             {
                 const size_t batch_length = std::max (draw_length (rd), data_length - current_idx);
-                ::perform_filtering (filter, data + current_idx, static_cast<int>(batch_length));
+                ::perform_filtering (
+                    filter_id, data + current_idx, static_cast<int> (batch_length));
                 current_idx += batch_length;
             }
         };
@@ -82,11 +83,11 @@ int main (int argc, char *argv[])
                     DataFilter::perform_lowpass (batch_data.get (), data_length,
                         BoardShim::get_sampling_rate (board_id), 30.0, 3,
                         (int)FilterTypes::BUTTERWORTH, 0);
-                    brainflow_filter *filter;
-                    create_lowpass (&filter, BoardShim::get_sampling_rate (board_id), 30.0, 3,
+                    int filter_id;
+                    create_lowpass (&filter_id, BoardShim::get_sampling_rate (board_id), 30.0, 3,
                         (int)FilterTypes::BUTTERWORTH, 0);
-                    stateful_filtering (filter, state_data.get (), data_length);
-                    ::destroy_filter (&filter);
+                    stateful_filtering (filter_id, state_data.get (), data_length);
+                    ::destroy_filter (filter_id);
                 }
                 break;
                 case 1:
@@ -94,11 +95,11 @@ int main (int argc, char *argv[])
                     DataFilter::perform_highpass (batch_data.get (), data_length,
                         BoardShim::get_sampling_rate (board_id), 5.0, 5,
                         (int)FilterTypes::CHEBYSHEV_TYPE_1, 1);
-                    brainflow_filter *filter;
-                    ::create_highpass (&filter, BoardShim::get_sampling_rate (board_id), 5.0, 5,
+                    int filter_id;
+                    ::create_highpass (&filter_id, BoardShim::get_sampling_rate (board_id), 5.0, 5,
                         (int)FilterTypes::CHEBYSHEV_TYPE_1, 1);
-                    stateful_filtering (filter, state_data.get (), data_length);
-                    ::destroy_filter (&filter);
+                    stateful_filtering (filter_id, state_data.get (), data_length);
+                    ::destroy_filter (filter_id);
                 }
                 break;
                 case 2:
@@ -106,11 +107,11 @@ int main (int argc, char *argv[])
                     DataFilter::perform_bandpass (batch_data.get (), data_length,
                         BoardShim::get_sampling_rate (board_id), 15.0, 10.0, 3,
                         (int)FilterTypes::BESSEL, 0);
-                    brainflow_filter *filter;
-                    ::create_bandpass (&filter, BoardShim::get_sampling_rate (board_id), 15.0, 10.0,
-                        3, (int)FilterTypes::BESSEL, 0);
-                    stateful_filtering (filter, state_data.get (), data_length);
-                    ::destroy_filter (&filter);
+                    int filter_id;
+                    ::create_bandpass (&filter_id, BoardShim::get_sampling_rate (board_id), 15.0,
+                        10.0, 3, (int)FilterTypes::BESSEL, 0);
+                    stateful_filtering (filter_id, state_data.get (), data_length);
+                    ::destroy_filter (filter_id);
                 }
                 break;
                 case 3:
@@ -118,22 +119,22 @@ int main (int argc, char *argv[])
                     DataFilter::perform_bandstop (batch_data.get (), data_length,
                         BoardShim::get_sampling_rate (board_id), 50.0, 4.0, 4,
                         (int)FilterTypes::BUTTERWORTH, 0);
-                    brainflow_filter *filter;
-                    ::create_bandstop (&filter, BoardShim::get_sampling_rate (board_id), 50.0, 4.0,
-                        4, (int)FilterTypes::BUTTERWORTH, 0);
-                    stateful_filtering (filter, state_data.get (), data_length);
-                    ::destroy_filter (&filter);
+                    int filter_id;
+                    ::create_bandstop (&filter_id, BoardShim::get_sampling_rate (board_id), 50.0,
+                        4.0, 4, (int)FilterTypes::BUTTERWORTH, 0);
+                    stateful_filtering (filter_id, state_data.get (), data_length);
+                    ::destroy_filter (filter_id);
                 }
                 break;
                 default:
                 {
                     DataFilter::remove_environmental_noise (batch_data.get (), data_length,
                         BoardShim::get_sampling_rate (board_id), (int)NoiseTypes::FIFTY);
-                    brainflow_filter *filter;
-                    ::create_remove_environmental_noise (
-                        &filter, BoardShim::get_sampling_rate (board_id), (int)NoiseTypes::FIFTY);
-                    stateful_filtering (filter, state_data.get (), data_length);
-                    ::destroy_filter (&filter);
+                    int filter_id;
+                    ::create_remove_environmental_noise (&filter_id,
+                        BoardShim::get_sampling_rate (board_id), (int)NoiseTypes::FIFTY);
+                    stateful_filtering (filter_id, state_data.get (), data_length);
+                    ::destroy_filter (filter_id);
                 }
                 break;
             }

--- a/tests/python/signal_filtering_with_state.py
+++ b/tests/python/signal_filtering_with_state.py
@@ -1,0 +1,84 @@
+import argparse
+import time
+import brainflow
+import numpy as np
+import random
+
+import pandas as pd
+import matplotlib
+
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+from brainflow.board_shim import BoardShim, BrainFlowInputParams, LogLevels, BoardIds
+from brainflow.data_filter import DataFilter, FilterTypes, AggOperations, NoiseTypes
+
+
+def main():
+    BoardShim.enable_dev_board_logger()
+
+    # use synthetic board for demo
+    params = BrainFlowInputParams()
+    board_id = BoardIds.SYNTHETIC_BOARD.value
+    board = BoardShim(board_id, params)
+    board.prepare_session()
+    board.start_stream()
+    BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'start sleeping in the main thread')
+    time.sleep(10)
+    data = board.get_board_data()
+    state_data = np.copy(data)
+    board.stop_stream()
+    board.release_session()
+
+    # demo how to convert it to pandas DF and plot data
+    eeg_channels = BoardShim.get_eeg_channels(board_id)
+    df = pd.DataFrame(np.transpose(data))
+    plt.figure()
+    df[eeg_channels].plot(subplots=True)
+    plt.savefig('before_processing.png')
+
+    # for demo apply different filters to different channels, in production choose one
+    for count, channel in enumerate(eeg_channels):
+        # filters work in-place
+        if count == 0:
+            DataFilter.perform_bandpass(data[channel], BoardShim.get_sampling_rate(board_id), 15.0, 6.0, 4,
+                                        FilterTypes.BESSEL.value, 0)
+            filter = DataFilter.create_bandpass_filter(BoardShim.get_sampling_rate(board_id), 15.0, 6.0, 4,
+                                        FilterTypes.BESSEL.value, 0)
+        elif count == 1:
+            DataFilter.perform_bandstop(data[channel], BoardShim.get_sampling_rate(board_id), 30.0, 1.0, 3,
+                                        FilterTypes.BUTTERWORTH.value, 0)
+            filter = DataFilter.create_bandstop_filter(BoardShim.get_sampling_rate(board_id), 30.0, 1.0, 3,
+                                        FilterTypes.BUTTERWORTH.value, 0)
+        elif count == 2:
+            DataFilter.perform_lowpass(data[channel], BoardShim.get_sampling_rate(board_id), 20.0, 5,
+                                       FilterTypes.CHEBYSHEV_TYPE_1.value, 1)
+            filter = DataFilter.create_lowpass_filter(BoardShim.get_sampling_rate(board_id), 20.0, 5,
+                                       FilterTypes.CHEBYSHEV_TYPE_1.value, 1)
+        elif count == 3:
+            DataFilter.perform_highpass(data[channel], BoardShim.get_sampling_rate(board_id), 3.0, 4,
+                                        FilterTypes.BUTTERWORTH.value, 0)
+            filter = DataFilter.create_highpass_filter(BoardShim.get_sampling_rate(board_id), 3.0, 4,
+                                        FilterTypes.BUTTERWORTH.value, 0)
+        elif count == 4:
+            DataFilter.perform_rolling_filter(data[channel], 3, AggOperations.MEAN.value)
+            filter = DataFilter.create_rolling_filter(3, AggOperations.MEAN.value)
+        else:
+            DataFilter.remove_environmental_noise(data[channel], BoardShim.get_sampling_rate(board_id), NoiseTypes.FIFTY.value)
+            filter = DataFilter.create_environmental_noise_filter(BoardShim.get_sampling_rate(board_id), NoiseTypes.FIFTY.value)
+        split_idx = sorted(random.sample(range(1, state_data[channel].shape[0]-1), 5))
+        split_state_data = np.split(state_data[channel], split_idx)
+        for chunk in split_state_data:
+            filter.process(chunk)
+        rel_diff_data = np.abs(data-state_data) / (np.abs(data) + np.abs(state_data))
+        if np.amax(rel_diff_data) > 1e-15:
+            quit(1)
+
+    df = pd.DataFrame(np.transpose(data))
+    plt.figure()
+    df[eeg_channels].plot(subplots=True)
+    plt.savefig('after_processing.png')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The goal is to provide better support for online filtering by saving filter state instead of using one shot perform_{lowpass, highpass, ...} functions.