### PR TITLE
remove parameter to board.get_board_data()

### DIFF
--- a/tests/python/downsampling.py
+++ b/tests/python/downsampling.py
@@ -16,7 +16,7 @@ def main():
     board.start_stream()
     BoardShim.log_message(LogLevels.LEVEL_INFO.value, 'start sleeping in the main thread')
     time.sleep(10)
-    data = board.get_board_data(20)
+    data = board.get_board_data()
     board.stop_stream()
     board.release_session()
 


### PR DESCRIPTION
I tried this from the docs and it gave me an error, I compared it with the other files and I think the fix is to remove the parameter