### PR TITLE
change ftdi latency automatically

### DIFF
--- a/src/board_controller/openbci/openbci_serial_board.cpp
+++ b/src/board_controller/openbci/openbci_serial_board.cpp
@@ -138,12 +138,14 @@ int OpenBCISerialBoard::status_check ()
     int count = 0;
     int max_empty_seq = 5;
     int num_empty_attempts = 0;
+    std::string resp = "";
 
     for (int i = 0; i < 500; i++)
     {
         int res = serial->read_from_serial_port (buf, 1);
         if (res > 0)
         {
+            resp += buf[0];
             num_empty_attempts = 0;
             // board is ready if there are '$$$'
             if (buf[0] == '$')
@@ -164,7 +166,8 @@ int OpenBCISerialBoard::status_check ()
             num_empty_attempts++;
             if (num_empty_attempts > max_empty_seq)
             {
-                safe_logger (spdlog::level::err, "board doesnt send welcome characters!");
+                safe_logger (spdlog::level::err, "board doesnt send welcome characters! Msg: {}",
+                    resp.c_str ());
                 return (int)BrainFlowExitCodes::BOARD_NOT_READY_ERROR;
             }
         }

--- a/src/board_controller/openbci/openbci_serial_board.cpp
+++ b/src/board_controller/openbci/openbci_serial_board.cpp
@@ -188,7 +188,7 @@ int OpenBCISerialBoard::prepare_session ()
         return (int)BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR;
     }
 #ifdef _WIN32
-    LONG res = set_ftdi_latency_in_registry (1);
+    LONG res = set_ftdi_latency_in_registry (1, params.serial_port);
     if (res != ERROR_SUCCESS)
     {
         safe_logger (spdlog::level::warn,

--- a/src/utils/inc/windows_registry.h
+++ b/src/utils/inc/windows_registry.h
@@ -1,0 +1,168 @@
+#pragma once
+
+#include <string>
+#include <windows.h>
+
+#include <devguid.h>
+#include <ntddser.h>
+#include <setupapi.h>
+#include <winerror.h>
+
+#pragma comment(lib, "Advapi32.lib")
+#pragma comment(lib, "SetupAPI.lib")
+
+static GUID GUID_FTDI_PORTS = {
+    0x4d36e978, 0xe325, 0x11ce, 0xbf, 0xc1, 0x08, 0x00, 0x2b, 0xe1, 0x03, 0x18};
+
+inline LONG set_dword_reg_key (
+    HKEY key, const std::wstring &path, const std::wstring &value_name, DWORD value)
+{
+    HKEY final_key;
+    LONG res = RegOpenKeyExW (key, path.c_str (), 0, KEY_SET_VALUE, &final_key);
+    if (res == ERROR_SUCCESS)
+    {
+        res = RegSetValueExW (final_key, value_name.c_str (), 0, REG_DWORD,
+            reinterpret_cast<LPBYTE> (&value), sizeof (DWORD));
+        RegCloseKey (final_key);
+    }
+    return res;
+}
+
+inline LONG get_dword_reg_key (HKEY key, const std::wstring &path, const std::wstring &value_name,
+    DWORD &value, DWORD default_value)
+{
+    value = default_value;
+    HKEY final_key;
+    LONG res = RegOpenKeyExW (key, path.c_str (), 0, KEY_READ, &final_key);
+    if (res == ERROR_SUCCESS)
+    {
+        DWORD buffer_size (sizeof (DWORD));
+        DWORD result (0);
+        res = RegQueryValueExW (final_key, value_name.c_str (), 0, NULL,
+            reinterpret_cast<LPBYTE> (&result), &buffer_size);
+        if (res == ERROR_SUCCESS)
+        {
+            value = result;
+        }
+        RegCloseKey (final_key);
+    }
+    return res;
+}
+
+inline LONG get_bool_reg_key (HKEY key, const std::wstring &path, const std::wstring &value_name,
+    bool &value, bool default_value)
+{
+    DWORD def_value ((default_value) ? 1 : 0);
+    DWORD result (def_value);
+    LONG res = get_dword_reg_key (key, path.c_str (), value_name.c_str (), result, def_value);
+    if (res = ERROR_SUCCESS)
+    {
+        value = (result != 0) ? true : false;
+    }
+    return res;
+}
+
+inline LONG get_str_reg_key (HKEY key, const std::wstring &path, const std::wstring &value_name,
+    std::wstring &value, const std::wstring &default_value)
+{
+    value = default_value;
+    HKEY final_key;
+    LONG res = RegOpenKeyExW (key, path.c_str (), 0, KEY_READ, &final_key);
+    if (res == ERROR_SUCCESS)
+    {
+        WCHAR buffer[512];
+        DWORD buffer_size = sizeof (buffer);
+        LONG res = RegQueryValueExW (
+            final_key, value_name.c_str (), 0, NULL, (LPBYTE)buffer, &buffer_size);
+        if (res == ERROR_SUCCESS)
+        {
+            value = buffer;
+        }
+        RegCloseKey (final_key);
+    }
+    return res;
+}
+
+inline LONG restart_usb_devices ()
+{
+    LONG res = ERROR_SUCCESS;
+    SP_DEVINFO_DATA device_info_data = {sizeof (device_info_data)};
+    HDEVINFO dev_info = SetupDiGetClassDevs (&GUID_FTDI_PORTS, 0, 0, DIGCF_PRESENT);
+    if (dev_info != INVALID_HANDLE_VALUE)
+    {
+        DWORD required_size = 0;
+        for (int i = 0; SetupDiEnumDeviceInfo (dev_info, i, &device_info_data); i++)
+        {
+            DWORD data_t;
+            char friendly_name[2046] = {0};
+            DWORD buffer_size = 2046;
+            DWORD req_bufsize = 0;
+            // get device description information
+            if (SetupDiGetDeviceRegistryPropertyA (dev_info, &device_info_data, SPDRP_FRIENDLYNAME,
+                    &data_t, (PBYTE)friendly_name, buffer_size, &req_bufsize))
+            {
+                std::string name (friendly_name);
+                if (name.find ("COM", 0) != std::string::npos)
+                {
+                    // try to restart
+                    if (!SetupDiRestartDevices (dev_info, &device_info_data))
+                    {
+                        res = GetLastError ();
+                    }
+                    Sleep (5000); // no idea about better option to wait after reboot
+                }
+            }
+        }
+    }
+    else
+    {
+        res = GetLastError ();
+    }
+    return res;
+}
+
+
+inline LONG set_ftdi_latency_in_registry (int latency_ms)
+{
+    HKEY ftdi_parent_key;
+    DWORD child_counter = 0;
+    bool need_restart = false;
+    LONG res = RegOpenKeyExW (HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Enum\\FTDIBUS", 0,
+        KEY_ENUMERATE_SUB_KEYS, &ftdi_parent_key);
+
+    while (res == ERROR_SUCCESS)
+    {
+        WCHAR child_name[4096];
+        DWORD child_size = sizeof (child_name);
+        res = RegEnumKeyExW (
+            ftdi_parent_key, child_counter, child_name, &child_size, NULL, NULL, NULL, NULL);
+        if (res == ERROR_SUCCESS)
+        {
+            child_counter++;
+            std::wstring full_name = std::wstring (L"SYSTEM\\CurrentControlSet\\Enum\\FTDIBUS\\") +
+                std::wstring (child_name) + std::wstring (L"\\0000\\Device Parameters");
+            DWORD current_value = 0;
+            if (get_dword_reg_key (HKEY_LOCAL_MACHINE, full_name, L"LatencyTimer", current_value,
+                    1) == ERROR_SUCCESS)
+            {
+                if (current_value != latency_ms)
+                {
+                    if (set_dword_reg_key (HKEY_LOCAL_MACHINE, full_name, L"LatencyTimer",
+                            latency_ms) == ERROR_SUCCESS)
+                    {
+                        need_restart = true;
+                    }
+                }
+            }
+        }
+    }
+    if (need_restart)
+    {
+        res = restart_usb_devices ();
+    }
+    else
+    {
+        res = ERROR_SUCCESS;
+    }
+    return res;
+}

--- a/src/utils/inc/windows_registry.h
+++ b/src/utils/inc/windows_registry.h
@@ -94,8 +94,8 @@ inline LONG restart_usb_devices ()
         for (int i = 0; SetupDiEnumDeviceInfo (dev_info, i, &device_info_data); i++)
         {
             DWORD data_t;
-            char friendly_name[2046] = {0};
-            DWORD buffer_size = 2046;
+            char friendly_name[4096] = {0};
+            DWORD buffer_size = 4096;
             DWORD req_bufsize = 0;
             // get device description information
             if (SetupDiGetDeviceRegistryPropertyA (dev_info, &device_info_data, SPDRP_FRIENDLYNAME,
@@ -109,7 +109,7 @@ inline LONG restart_usb_devices ()
                     {
                         res = GetLastError ();
                     }
-                    Sleep (5000); // no idea about better option to wait after reboot
+                    Sleep (7000); // no idea about better option to wait after reboot
                 }
             }
         }
@@ -120,7 +120,6 @@ inline LONG restart_usb_devices ()
     }
     return res;
 }
-
 
 inline LONG set_ftdi_latency_in_registry (int latency_ms)
 {
@@ -164,5 +163,6 @@ inline LONG set_ftdi_latency_in_registry (int latency_ms)
     {
         res = ERROR_SUCCESS;
     }
+    RegCloseKey (ftdi_parent_key);
     return res;
 }

--- a/src/utils/inc/windows_registry.h
+++ b/src/utils/inc/windows_registry.h
@@ -86,6 +86,7 @@ inline LONG get_str_reg_key (HKEY key, const std::wstring &path, const std::wstr
 inline LONG restart_usb_device (std::string port_name)
 {
     LONG res = ERROR_SUCCESS;
+    bool need_wait = false;
     SP_DEVINFO_DATA device_info_data = {sizeof (device_info_data)};
     HDEVINFO dev_info = SetupDiGetClassDevs (&GUID_FTDI_PORTS, 0, 0, DIGCF_PRESENT);
     if (dev_info != INVALID_HANDLE_VALUE)
@@ -105,11 +106,14 @@ inline LONG restart_usb_device (std::string port_name)
                 if (name.find (port_name) != std::string::npos)
                 {
                     // try to restart
-                    if (!SetupDiRestartDevices (dev_info, &device_info_data))
+                    if (SetupDiRestartDevices (dev_info, &device_info_data))
+                    {
+                        need_wait = true;
+                    }
+                    else
                     {
                         res = GetLastError ();
                     }
-                    Sleep (7000); // no idea about better option to wait after reboot
                 }
             }
         }
@@ -117,6 +121,10 @@ inline LONG restart_usb_device (std::string port_name)
     else
     {
         res = GetLastError ();
+    }
+    if (need_wait)
+    {
+        Sleep (7000); // no idea about better option to wait after reboot
     }
     return res;
 }

--- a/src/utils/inc/windows_registry.h
+++ b/src/utils/inc/windows_registry.h
@@ -83,7 +83,7 @@ inline LONG get_str_reg_key (HKEY key, const std::wstring &path, const std::wstr
     return res;
 }
 
-inline LONG restart_usb_devices ()
+inline LONG restart_usb_device (std::string port_name)
 {
     LONG res = ERROR_SUCCESS;
     SP_DEVINFO_DATA device_info_data = {sizeof (device_info_data)};
@@ -102,7 +102,7 @@ inline LONG restart_usb_devices ()
                     &data_t, (PBYTE)friendly_name, buffer_size, &req_bufsize))
             {
                 std::string name (friendly_name);
-                if (name.find ("COM", 0) != std::string::npos)
+                if (name.find (port_name) != std::string::npos)
                 {
                     // try to restart
                     if (!SetupDiRestartDevices (dev_info, &device_info_data))
@@ -121,7 +121,7 @@ inline LONG restart_usb_devices ()
     return res;
 }
 
-inline LONG set_ftdi_latency_in_registry (int latency_ms)
+inline LONG set_ftdi_latency_in_registry (int latency_ms, std::string port_name)
 {
     HKEY ftdi_parent_key;
     DWORD child_counter = 0;
@@ -157,7 +157,7 @@ inline LONG set_ftdi_latency_in_registry (int latency_ms)
     }
     if (need_restart)
     {
-        res = restart_usb_devices ();
+        res = restart_usb_device (port_name);
     }
     else
     {


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

It should apply ftdi buffer fix automatically for windows, directly inside `prepare_session` method

Links used: 
* https://docs.microsoft.com/en-us/windows/win32/api/setupapi/nf-setupapi-setupdirestartdevices 
* https://docs.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regopenkeyexa

How it works:

* change registry key
* restart the device programmatically
* restart is done only if ftdi buffer fix was not applied before

Potential issues, need to test further:

* it may affect some non-ftdi devices(mouse, keyboard, other boards, etc), during testing need to plug whatever you can to your PC. I didnt have this issue during testing
* it doesnt use correct pipeline for device restart. Correct pipeline disable cyton->unplug dongle -> plug dongle -> enable cyton, we cannot disable cyton first, so this code just restarts dongle and keeps cyton up and running. For me it worked fine
* I had to hardcode some timeout after device restart(currently 5 secs). Didnt find a way to do it wo `Sleep` and maybe 5 secs is not the best value, need to tune it further. Also it will lead to the extra delay for the 1st run

Demo:

Switch between 1 and 32 in compile time and plot the data
video: https://drive.google.com/file/d/1einLW4Vh0Sail9obGw3YCEbF-rZVo9hn/view?usp=sharing
