### PR TITLE
Update psd_len calculation in get_psd_welch

### DIFF
--- a/cpp_package/src/data_filter.cpp
+++ b/cpp_package/src/data_filter.cpp
@@ -257,7 +257,7 @@ std::pair<double *, double *> DataFilter::get_psd_welch (
         delete[] freq;
         throw BrainFlowException ("failed to get_psd_welch", res);
     }
-    *psd_len = data_len / 2 + 1;
+    *psd_len = nfft / 2 + 1;
     return std::make_pair (ampl, freq);
 }
 


### PR DESCRIPTION
This PR updates the psd_len calculation in get_psd_welch() to use nfft instead of data_len.