### PR TITLE
use add_dll_directory for python38

### DIFF
--- a/python_package/brainflow/board_shim.py
+++ b/python_package/brainflow/board_shim.py
@@ -144,10 +144,15 @@ class BoardControllerDLL(object):
             dll_path = 'lib/libBoardController.so'
         full_path = pkg_resources.resource_filename(__name__, dll_path)
         if os.path.isfile(full_path):
+            dir_path = os.path.abspath(os.path.dirname(full_path))
             # for python we load dll by direct path but this dll may depend on other dlls and they will not be found!
             # to solve it we can load all of them before loading the main one or change PATH\LD_LIBRARY_PATH env var.
             # env variable looks better, since it can be done only once for all dependencies
-            dir_path = os.path.abspath(os.path.dirname(full_path))
+            # for python 3.8 PATH env var doesnt work anymore
+            try:
+                os.add_dll_directory(dir_path)
+            except:
+                pass
             if platform.system() == 'Windows':
                 os.environ['PATH'] = dir_path + os.pathsep + os.environ.get('PATH', '')
             else:

--- a/python_package/brainflow/data_filter.py
+++ b/python_package/brainflow/data_filter.py
@@ -154,6 +154,11 @@ class DataHandlerDLL(object):
         full_path = pkg_resources.resource_filename(__name__, dll_path)
         if os.path.isfile(full_path):
             dir_path = os.path.abspath(os.path.dirname(full_path))
+            # for python 3.8 PATH env var doesnt work anymore
+            try:
+                os.add_dll_directory(dir_path)
+            except:
+                pass
             if platform.system() == 'Windows':
                 os.environ['PATH'] = dir_path + os.pathsep + os.environ.get('PATH', '')
             else:

--- a/python_package/brainflow/ml_model.py
+++ b/python_package/brainflow/ml_model.py
@@ -85,6 +85,10 @@ class MLModuleDLL(object):
             # to solve it we can load all of them before loading the main one or change PATH\LD_LIBRARY_PATH env var.
             # env variable looks better, since it can be done only once for all dependencies
             dir_path = os.path.abspath(os.path.dirname(full_path))
+            try:
+                os.add_dll_directory(dir_path)
+            except:
+                pass
             if platform.system() == 'Windows':
                 os.environ['PATH'] = dir_path + os.pathsep + os.environ.get('PATH', '')
             else:


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

From the Python 3.8 release notes:

DLL dependencies for extension modules and DLLs loaded with ctypes on Windows are now resolved more securely. Only the system paths, the directory containing the DLL or PYD file, and directories added with add_dll_directory() are searched for load-time dependencies. Specifically, PATH and the current working directory are no longer used, and modifications to these will no longer have any effect on normal DLL resolution. If your application relies on these mechanisms, you should check for add_dll_directory() and if it exists, use it to add your DLLs directory while loading your library. Note that Windows 7 users will need to ensure that Windows Update KB2533623 has been installed (this is also verified by the installer).