### PR TITLE
Fixed a an issue with memory being written to after it was freed, leading to abort signals from malloc

### DIFF
--- a/rust_package/brainflow/Cargo.toml
+++ b/rust_package/brainflow/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "1.0.29"
 
 [dev-dependencies]
 approx = "0.5.0"
+regex = "1.6.0"
 
 [build-dependencies]
 bindgen = { version = "0.59.1", optional = true }

--- a/rust_package/brainflow/src/board_shim.rs
+++ b/rust_package/brainflow/src/board_shim.rs
@@ -218,27 +218,25 @@ impl BoardShim {
     pub fn config_board<S: AsRef<str>>(&self, config: S) -> Result<String> {
         let config = CString::new(config.as_ref())?;
         let mut response_len = 0;
-        let mut c_string: [c_char; 8192] = [0; 8192];
+        let mut result_char_buffer: [c_char; 8192] = [0; 8192];
 
         let config = config.into_raw();
         let (res, response) = unsafe {
             let res = board_controller::config_board(
                 config,
-                c_string.as_mut_ptr(),
+                result_char_buffer.as_mut_ptr(),
                 &mut response_len,
                 self.board_id as c_int,
                 self.json_brainflow_input_params.as_ptr(),
             );
             let _ = CString::from_raw(config);
-            let resp = CStr::from_ptr(c_string.as_ptr());
+            let resp = CStr::from_ptr(result_char_buffer.as_ptr());
 
             (res, resp)
         };
         check_brainflow_exit_code(res)?;
         Ok(response
             .to_str()?
-            .split_at(response_len as usize)
-            .0
             .to_string())
     }
 
@@ -359,34 +357,30 @@ pub fn log_message<S: AsRef<str>>(log_level: LogLevels, message: S) -> Result<()
 
 /// Get board description as json.
 pub fn get_board_descr(board_id: BoardIds, preset: BrainFlowPresets) -> Result<String> {
+    const MAX_CHARS: usize = 16000;
     let mut response_len = 0;
-    let response = CString::new(Vec::with_capacity(16000))?;
-    let response = response.into_raw();
+    let mut result_char_buffer: [c_char; MAX_CHARS] = [0; MAX_CHARS];
     let (res, response) = unsafe {
-        let res = board_controller::get_board_descr(board_id as c_int, preset as c_int, response, &mut response_len);
-        let response = CString::from_raw(response);
+        let res = board_controller::get_board_descr(board_id as c_int, preset as c_int, result_char_buffer.as_mut_ptr(), &mut response_len);
+        let response = CStr::from_ptr(result_char_buffer.as_ptr());
         (res, response)
     };
     check_brainflow_exit_code(res)?;
-    Ok(response
-        .to_str()?
-        .split_at(response_len as usize)
-        .0
-        .to_string())
+    Ok(response.to_str()?.to_string())
 }
 
 /// Get names of EEG channels in 10-20 system if their location is fixed.
 pub fn get_eeg_names(board_id: BoardIds, preset: BrainFlowPresets) -> Result<Vec<String>> {
+    const MAX_CHARS: usize = 16000;
     let mut response_len = 0;
-    let response = CString::new(Vec::with_capacity(16000))?;
-    let response = response.into_raw();
+    let mut result_char_buffer: [c_char; MAX_CHARS] = [0; MAX_CHARS];
     let (res, response) = unsafe {
-        let res = board_controller::get_eeg_names(board_id as c_int, preset as c_int, response, &mut response_len);
-        let response = CString::from_raw(response);
+        let res = board_controller::get_eeg_names(board_id as c_int, preset as c_int, result_char_buffer.as_mut_ptr(), &mut response_len);
+        let response = CStr::from_ptr(result_char_buffer.as_ptr());
         (res, response)
     };
     check_brainflow_exit_code(res)?;
-    let names = response.to_str()?.split_at(response_len as usize).0;
+    let names = response.to_str()?;
 
     Ok(names
         .split(',')
@@ -413,36 +407,34 @@ pub fn get_board_presets(board_id: BoardIds) -> Result<Vec<usize>> {
 
 /// Get BoardShim version.
 pub fn get_version() -> Result<String> {
+    const MAX_CHARS: usize = 64;
     let mut response_len = 0;
-    let response = CString::new(Vec::with_capacity(64))?;
-    let response = response.into_raw();
+    let mut result_char_buffer: [c_char; MAX_CHARS] = [0; MAX_CHARS];
+
     let (res, response) = unsafe {
-        let res = board_controller::get_version_board_controller(response, &mut response_len, 64);
-        let response = CString::from_raw(response);
+        let res = board_controller::get_version_board_controller(result_char_buffer.as_mut_ptr(), &mut response_len, MAX_CHARS as i32);
+        let response = CStr::from_ptr(result_char_buffer.as_ptr());
         (res, response)
     };
     check_brainflow_exit_code(res)?;
-    let version = response.to_str()?.split_at(response_len as usize).0;
+    let version = response.to_str()?;
 
     Ok(version.to_string())
 }
 
 /// Get device name.
 pub fn get_device_name(board_id: BoardIds, preset: BrainFlowPresets) -> Result<String> {
+    const MAX_CHARS: usize = 4096;
     let mut response_len = 0;
-    let response = CString::new(Vec::with_capacity(4096))?;
-    let response = response.into_raw();
+    let mut result_char_buffer: [c_char; MAX_CHARS] = [0; MAX_CHARS];
+
     let (res, response) = unsafe {
-        let res = board_controller::get_device_name(board_id as c_int, preset as c_int, response, &mut response_len);
-        let response = CString::from_raw(response);
+        let res = board_controller::get_device_name(board_id as c_int, preset as c_int, result_char_buffer.as_mut_ptr(), &mut response_len);
+        let response = CStr::from_ptr(result_char_buffer.as_ptr());
         (res, response)
     };
     check_brainflow_exit_code(res)?;
-    Ok(response
-        .to_str()?
-        .split_at(response_len as usize)
-        .0
-        .to_string())
+    Ok(response.to_str()?.to_string())
 }
 
 macro_rules! gen_vec_fn {
@@ -521,3 +513,70 @@ gen_vec_fn!(
     resistance_channels,
     "Get list of resistance channels in resulting data table for a board."
 );
+
+#[cfg(test)]
+mod tests {
+    #[cfg(test)]
+    mod functions {
+        use crate::board_shim::{get_version, get_device_name, get_eeg_names, get_board_descr};
+        use crate::{BoardIds, BrainFlowPresets};
+
+        #[test]
+        fn test_it_gets_the_version() {
+            assert_eq!("0.0.1", get_version().unwrap());
+        }
+
+        #[test]
+        fn test_get_device_name() {
+            assert_eq!("Synthetic", get_device_name(BoardIds::SyntheticBoard, BrainFlowPresets::DefaultPreset).unwrap());
+        }
+
+        #[test]
+        fn test_get_eeg_names() {
+            assert_eq!(vec!["Fz", "C3", "Cz", "C4", "Pz", "PO7", "Oz", "PO8", "F5", "F7", "F3", "F1", "F2", "F4", "F6", "F8"],
+                       get_eeg_names(BoardIds::SyntheticBoard, BrainFlowPresets::DefaultPreset).unwrap());
+
+        }
+
+        #[test]
+        fn test_get_board_descr() {
+            let expected = "{\"accel_channels\":[17,18,19],\"battery_channel\":29,\
+            \"ecg_channels\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],\"eda_channels\":[23],\
+            \"eeg_channels\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],\"eeg_names\":\
+            \"Fz,C3,Cz,C4,Pz,PO7,Oz,PO8,F5,F7,F3,F1,F2,F4,F6,F8\",\"emg_channels\
+            \":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],\"eog_channels\
+            \":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],\"gyro_channels\
+            \":[20,21,22],\"marker_channel\":31,\"name\":\"Synthetic\",\"num_rows\":32,\
+            \"package_num_channel\":0,\"ppg_channels\":[24,25],\"resistance_channels\
+            \":[27,28],\"sampling_rate\":250,\"temperature_channels\":[26],\
+            \"timestamp_channel\":30}";
+
+            assert_eq!(expected,
+                       get_board_descr(BoardIds::SyntheticBoard, BrainFlowPresets::DefaultPreset).unwrap());
+
+        }
+    }
+
+
+    #[cfg(test)]
+    mod board_shim {
+        use crate::board_shim::BoardShim;
+        use crate::BoardIds;
+        use crate::brainflow_input_params::BrainFlowInputParams;
+
+        fn board_shim() -> BoardShim {
+            BoardShim::new(BoardIds::SyntheticBoard,
+                           BrainFlowInputParams::default()).unwrap()
+        }
+
+        #[test]
+        fn test_config_board() {
+            let board = board_shim();
+            board.prepare_session();
+            // synthetic board doesnt send any message back as it ignores config calls
+            assert_eq!("", board.config_board("x123456X").unwrap());
+
+        }
+    }
+
+}

--- a/rust_package/brainflow/src/board_shim.rs
+++ b/rust_package/brainflow/src/board_shim.rs
@@ -518,12 +518,19 @@ gen_vec_fn!(
 mod tests {
     #[cfg(test)]
     mod functions {
+        use regex::Regex;
+
         use crate::board_shim::{get_version, get_device_name, get_eeg_names, get_board_descr};
         use crate::{BoardIds, BrainFlowPresets};
 
+        fn assert_regex_matches(regex: &str, value: &str) {
+            let compiled_regex = Regex::new(regex).unwrap();
+            assert!(compiled_regex.is_match(value), "Expected to match {}, got {}", regex, value);
+        }
+
         #[test]
         fn test_it_gets_the_version() {
-            assert_eq!("0.0.1", get_version().unwrap());
+            assert_regex_matches(r"^\d+\.\d+\.\d+$", get_version().unwrap().as_str());
         }
 
         #[test]
@@ -540,20 +547,10 @@ mod tests {
 
         #[test]
         fn test_get_board_descr() {
-            let expected = "{\"accel_channels\":[17,18,19],\"battery_channel\":29,\
-            \"ecg_channels\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],\"eda_channels\":[23],\
-            \"eeg_channels\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],\"eeg_names\":\
-            \"Fz,C3,Cz,C4,Pz,PO7,Oz,PO8,F5,F7,F3,F1,F2,F4,F6,F8\",\"emg_channels\
-            \":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],\"eog_channels\
-            \":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],\"gyro_channels\
-            \":[20,21,22],\"marker_channel\":31,\"name\":\"Synthetic\",\"num_rows\":32,\
-            \"package_num_channel\":0,\"ppg_channels\":[24,25],\"resistance_channels\
-            \":[27,28],\"sampling_rate\":250,\"temperature_channels\":[26],\
-            \"timestamp_channel\":30}";
+            let pattern = r#"^.*"name"\w*:\w*"Synthetic".*$"#;
 
-            assert_eq!(expected,
-                       get_board_descr(BoardIds::SyntheticBoard, BrainFlowPresets::DefaultPreset).unwrap());
-
+            assert_regex_matches(pattern,
+                       get_board_descr(BoardIds::SyntheticBoard, BrainFlowPresets::DefaultPreset).unwrap().as_str());
         }
     }
 

--- a/rust_package/brainflow/src/board_shim.rs
+++ b/rust_package/brainflow/src/board_shim.rs
@@ -518,19 +518,14 @@ gen_vec_fn!(
 mod tests {
     #[cfg(test)]
     mod functions {
-        use regex::Regex;
-
+        use crate::test_helpers::assertions::assert_regex_matches;
+        use crate::test_helpers::consts::VERSION_PATTERN;
         use crate::board_shim::{get_version, get_device_name, get_eeg_names, get_board_descr};
         use crate::{BoardIds, BrainFlowPresets};
 
-        fn assert_regex_matches(regex: &str, value: &str) {
-            let compiled_regex = Regex::new(regex).unwrap();
-            assert!(compiled_regex.is_match(value), "Expected to match {}, got {}", regex, value);
-        }
-
         #[test]
         fn test_it_gets_the_version() {
-            assert_regex_matches(r"^\d+\.\d+\.\d+$", get_version().unwrap().as_str());
+            assert_regex_matches(VERSION_PATTERN, get_version().unwrap().as_str());
         }
 
         #[test]

--- a/rust_package/brainflow/src/data_filter.rs
+++ b/rust_package/brainflow/src/data_filter.rs
@@ -824,16 +824,15 @@ pub fn get_version() -> Result<String> {
 #[cfg(test)]
 mod tests {
     use std::{env, f64::consts::PI, fs};
-
     use ndarray::array;
-
     use crate::ffi::constants::WindowOperations;
-
+    use crate::test_helpers::assertions::assert_regex_matches;
+    use crate::test_helpers::consts::VERSION_PATTERN;
     use super::*;
 
     #[test]
-    fn test_get_version() {
-        assert_eq!("0.0.1", get_version().unwrap());
+    fn test_it_gets_the_version() {
+        assert_regex_matches(VERSION_PATTERN, get_version().unwrap().as_str());
     }
 
     #[test]

--- a/rust_package/brainflow/src/data_filter.rs
+++ b/rust_package/brainflow/src/data_filter.rs
@@ -3,7 +3,8 @@ use ndarray::{Array1, Array2, Array3, ArrayBase};
 use num::Complex;
 use num_complex::Complex64;
 use std::os::raw::c_int;
-use std::{ffi::CString, os::raw::c_double};
+use std::{ffi::CString, ffi::CStr, os::raw::c_double};
+use std::os::raw::c_char;
 
 use crate::error::{BrainFlowError, Error};
 use crate::ffi::data_handler;
@@ -807,18 +808,17 @@ where
 
 /// Get DataFilter version.
 pub fn get_version() -> Result<String> {
+    const MAX_CHARS: usize = 64;
     let mut response_len = 0;
-    let response = CString::new(Vec::with_capacity(64))?;
-    let response = response.into_raw();
+    let mut result_char_buffer: [c_char; MAX_CHARS] = [0; MAX_CHARS];
     let (res, response) = unsafe {
-        let res = data_handler::get_version_data_handler(response, &mut response_len, 64);
-        let response = CString::from_raw(response);
+        let res = data_handler::get_version_data_handler(result_char_buffer.as_mut_ptr(), &mut response_len, MAX_CHARS as i32);
+        let response = CStr::from_ptr(result_char_buffer.as_mut_ptr());
         (res, response)
     };
     check_brainflow_exit_code(res)?;
-    let version = response.to_str()?.split_at(response_len as usize).0;
 
-    Ok(version.to_string())
+    Ok(response.to_str()?.to_string())
 }
 
 #[cfg(test)]
@@ -830,6 +830,11 @@ mod tests {
     use crate::ffi::constants::WindowOperations;
 
     use super::*;
+
+    #[test]
+    fn test_get_version() {
+        assert_eq!("0.0.1", get_version().unwrap());
+    }
 
     #[test]
     fn wavelet_inverse_transform_equals_input_data() {
@@ -846,7 +851,7 @@ mod tests {
         println!("{:?}", restored_fft);
 
         println!("{:?}", data);
-        let wavelet_data = perform_wavelet_transform(&mut data, "db3", 3).unwrap();
+        let wavelet_data = perform_wavelet_transform(&mut data, WaveletTypes::Db3, 3, WaveletExtensionTypes::Periodic).unwrap();
         let restored_wavelet = perform_inverse_wavelet_transform(wavelet_data).unwrap();
         println!("{:?}", restored_wavelet);
         for (d, r) in data.iter().zip(restored_wavelet) {

--- a/rust_package/brainflow/src/lib.rs
+++ b/rust_package/brainflow/src/lib.rs
@@ -22,6 +22,7 @@ mod ffi;
 /// Used to calculate derivative metrics from raw data.
 pub mod ml_model;
 
+mod test_helpers;
 /// Store all supported BrainFlow Errors.
 pub use error::BrainFlowError;
 /// Enum to store all supported Agg Operations.

--- a/rust_package/brainflow/src/ml_model.rs
+++ b/rust_package/brainflow/src/ml_model.rs
@@ -120,9 +120,11 @@ pub fn get_version() -> Result<String> {
 #[cfg(test)]
 mod tests {
     use crate::ml_model::get_version;
+    use crate::test_helpers::assertions::assert_regex_matches;
+    use crate::test_helpers::consts::VERSION_PATTERN;
 
     #[test]
-    fn test_get_version() {
-        assert_eq!("0.0.1", get_version().unwrap());
+    fn test_it_gets_the_version() {
+        assert_regex_matches(VERSION_PATTERN, get_version().unwrap().as_str());
     }
 }

--- a/rust_package/brainflow/src/ml_model.rs
+++ b/rust_package/brainflow/src/ml_model.rs
@@ -1,6 +1,6 @@
 use std::{
-    ffi::CString,
-    os::raw::{c_double, c_int},
+    ffi::{CString, CStr},
+    os::raw::{c_double, c_int, c_char},
 };
 
 use crate::{
@@ -105,16 +105,24 @@ pub fn release_all() -> Result<()> {
 
 /// Get DataFilter version.
 pub fn get_version() -> Result<String> {
+    const MAX_CHARS: usize = 64;
     let mut response_len = 0;
-    let response = CString::new(Vec::with_capacity(64))?;
-    let response = response.into_raw();
+    let mut result_char_buffer: [c_char; MAX_CHARS] = [0; MAX_CHARS];
     let (res, response) = unsafe {
-        let res = ml_module::get_version_ml_module(response, &mut response_len, 64);
-        let response = CString::from_raw(response);
+        let res = ml_module::get_version_ml_module(result_char_buffer.as_mut_ptr(), &mut response_len, MAX_CHARS as i32);
+        let response = CStr::from_ptr(result_char_buffer.as_ptr());
         (res, response)
     };
     check_brainflow_exit_code(res)?;
-    let version = response.to_str()?.split_at(response_len as usize).0;
+    Ok(response.to_str()?.to_string())
+}
 
-    Ok(version.to_string())
+#[cfg(test)]
+mod tests {
+    use crate::ml_model::get_version;
+
+    #[test]
+    fn test_get_version() {
+        assert_eq!("0.0.1", get_version().unwrap());
+    }
 }

--- a/rust_package/brainflow/src/test_helpers.rs
+++ b/rust_package/brainflow/src/test_helpers.rs
@@ -1,0 +1,14 @@
+#[cfg(test)]
+pub(crate) mod assertions {
+    use regex::Regex;
+
+    pub(crate) fn assert_regex_matches(regex: &str, value: &str) {
+        let compiled_regex = Regex::new(regex).unwrap();
+        assert!(compiled_regex.is_match(value), "Expected to match {}, got {}", regex, value);
+    }
+}
+
+#[cfg(test)]
+pub mod consts {
+    pub(crate) const VERSION_PATTERN: &str = r"^\d+\.\d+\.\d+$";
+}


### PR DESCRIPTION
There was an issue while calling the config_board method from the rust library, leading to SIGABRT killing the process. This was a bit hard to track down as exactly when the abort happened wasnt deterministic. It could be at any time a memory allocation via malloc took place after config_board was called. The abort was due to the allocator detecting that memory had been written to after it was freed  Ultimately it was determined that the c(++) code that was called was performing a strcpy in to response CString that was passed to this code. This copy was resulting in the memory being written to after it was freed.

If you refer to the doco for CString.into_raw() you will see "The C side must not modify the length of the string (by writing a null somewhere inside the string or removing the final one) before it makes it back into Rust using [CString::from_raw](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.from_raw). See the safety section in [CString::from_raw](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.from_raw).". The code here as it was was breaking this constraint. I am not 100% sure if this was causing the memory to be written to after it was freed or not, but using a preallocated character buffer whose lifecycle was managed on the stack seems to have fixed the issue.