### PR TITLE
fix BrainFlowInputParams < operator

### DIFF
--- a/src/board_controller/inc/brainflow_input_params.h
+++ b/src/board_controller/inc/brainflow_input_params.h
@@ -39,10 +39,10 @@ struct BrainFlowInputParams
     bool operator< (const struct BrainFlowInputParams &other) const
     {
         return std::tie (serial_port, mac_address, ip_address, ip_port, ip_protocol, other_info,
-                   timeout, serial_number, file, preset,
-                   master_board) < std::tie (other.serial_port, other.mac_address, other.ip_address,
-                                       other.ip_port, other.ip_protocol, other.other_info, timeout,
-                                       serial_number, file, preset, master_board);
+                   timeout, serial_number, file, preset, master_board) <
+            std::tie (other.serial_port, other.mac_address, other.ip_address, other.ip_port,
+                other.ip_protocol, other.other_info, other.timeout, other.serial_number, other.file,
+                other.preset, other.master_board);
     }
 
     bool operator> (const struct BrainFlowInputParams &other) const


### PR DESCRIPTION
The BrainFlowInputParams: timeout, serial_number, file, preset, and master_board did not have "other." in front of them in the less than operator. This pr fixes the multiple streaming boards issue if only changing those specific parameters.