### PR TITLE
Rename `revert_array()` to`reverse_array()`

### DIFF
--- a/src/data_handler/data_handler.cpp
+++ b/src/data_handler/data_handler.cpp
@@ -178,9 +178,9 @@ int perform_lowpass (double *data, int data_len, int sampling_rate, double cutof
         (filter_type == (int)FilterTypes::CHEBYSHEV_TYPE_1_ZERO_PHASE) ||
         (filter_type == (int)FilterTypes::BESSEL_ZERO_PHASE))
     {
-        revert_array (data, data_len);
+        reverse_array (data, data_len);
         f->process (data_len, filter_data);
-        revert_array (data, data_len);
+        reverse_array (data, data_len);
     }
     delete f;
 
@@ -241,9 +241,9 @@ int perform_highpass (double *data, int data_len, int sampling_rate, double cuto
         (filter_type == (int)FilterTypes::CHEBYSHEV_TYPE_1_ZERO_PHASE) ||
         (filter_type == (int)FilterTypes::BESSEL_ZERO_PHASE))
     {
-        revert_array (data, data_len);
+        reverse_array (data, data_len);
         f->process (data_len, filter_data);
-        revert_array (data, data_len);
+        reverse_array (data, data_len);
     }
     delete f;
 
@@ -309,9 +309,9 @@ int perform_bandpass (double *data, int data_len, int sampling_rate, double star
         (filter_type == (int)FilterTypes::CHEBYSHEV_TYPE_1_ZERO_PHASE) ||
         (filter_type == (int)FilterTypes::BESSEL_ZERO_PHASE))
     {
-        revert_array (data, data_len);
+        reverse_array (data, data_len);
         f->process (data_len, filter_data);
-        revert_array (data, data_len);
+        reverse_array (data, data_len);
     }
     delete f;
 
@@ -377,9 +377,9 @@ int perform_bandstop (double *data, int data_len, int sampling_rate, double star
         (filter_type == (int)FilterTypes::CHEBYSHEV_TYPE_1_ZERO_PHASE) ||
         (filter_type == (int)FilterTypes::BESSEL_ZERO_PHASE))
     {
-        revert_array (data, data_len);
+        reverse_array (data, data_len);
         f->process (data_len, filter_data);
-        revert_array (data, data_len);
+        reverse_array (data, data_len);
     }
     delete f;
 

--- a/src/data_handler/inc/common_data_handler_helpers.h
+++ b/src/data_handler/inc/common_data_handler_helpers.h
@@ -36,7 +36,11 @@ inline double stddev (double data[], int len)
     return sqrt (deviation / len);
 }
 
-inline void revert_array (double data[], int len)
+
+// Reverses the drection of an array of doubles.
+// I.e. the first element (0) is replaced by the last (len - 1),
+// element 1 is replaced by element (len - 1 - 1), etc.
+inline void reverse_array (double data[], int len)
 {
     for (int i = 0; i < len / 2; i++)
     {


### PR DESCRIPTION
Without comments I'm not totally sure as to the reasons it's being used at the callsites, but, I think `revert_array()` is reversing an array of doubles - i.e. it's flipping it round in-place so that the order is now backwards. I think renaming it `reverse_array()` makes its purpose clearer. Reverting to me implies that the array is being returned to some previous state (like `brz revert` on a file), which is different to reversing the order. 

However feel free to correct me if I have misunderstood! Longer-term I think it would make sense to use a [reverse range](https://en.cppreference.com/w/cpp/algorithm/ranges/reverse) if possible. We shouldn't make copies unless we have to, although I understand many libraries used by brainflow may not yet be aware of ranges, iterator adaptors, etc..


