### PR TITLE
Add log message for EOF in PlaybackFileBoard.

### DIFF
--- a/src/board_controller/playback_file_board.cpp
+++ b/src/board_controller/playback_file_board.cpp
@@ -246,7 +246,8 @@ void PlaybackFileBoard::read_thread (int preset, std::string file)
         }
         if ((!loopback) && (res == NULL))
         {
-            if (!reached_end){
+            if (!reached_end)
+            {
                 reached_end = true;
                 // Log just once to inform the user that we have reached the endof the file, as we stop sending any samples.
                 // The user-programmer could be waiting as the stream needs to be stopped manually.

--- a/src/board_controller/playback_file_board.cpp
+++ b/src/board_controller/playback_file_board.cpp
@@ -213,6 +213,7 @@ void PlaybackFileBoard::read_thread (int preset, std::string file)
     int timestamp_channel = board_preset["timestamp_channel"];
     double accumulated_time_delta = 0.0;
 
+    bool reached_end = false;
     while (keep_alive)
     {
         auto start = std::chrono::high_resolution_clock::now ();
@@ -245,6 +246,12 @@ void PlaybackFileBoard::read_thread (int preset, std::string file)
         }
         if ((!loopback) && (res == NULL))
         {
+            if (!reached_end){
+                reached_end = true;
+                // Log just once to inform the user that we have reached the endof the file, as we stop sending any samples.
+                // The user-programmer could be waiting as the stream needs to be stopped manually.
+                safe_logger (spdlog::level::trace, "End of file reached and not set to loop. Sleeping.");
+            }
 // busy wait instead exit
 #ifdef _WIN32
             Sleep (1);

--- a/src/board_controller/playback_file_board.cpp
+++ b/src/board_controller/playback_file_board.cpp
@@ -249,9 +249,11 @@ void PlaybackFileBoard::read_thread (int preset, std::string file)
             if (!reached_end)
             {
                 reached_end = true;
-                // Log just once to inform the user that we have reached the endof the file, as we stop sending any samples.
-                // The user-programmer could be waiting as the stream needs to be stopped manually.
-                safe_logger (spdlog::level::trace, "End of file reached and not set to loop. Sleeping.");
+                // Log just once to inform the user that we have reached the endof the file, as we
+                // stop sending any samples. The user-programmer could be waiting as the stream
+                // needs to be stopped manually.
+                safe_logger (
+                    spdlog::level::trace, "End of file reached and not set to loop. Sleeping.");
             }
 // busy wait instead exit
 #ifdef _WIN32


### PR DESCRIPTION
BrainFlow's stream doesn't block, so, the user calling into the session has to use some other method - sleeping, or waiting for user input before terminating the session.

When playing back a file, and not looping, it's possible the file will ned before the user is expecting. At this point, the file reader will sleep, but no message is printed, so the pipeline silently stops sending values.

This simply adds a logging line for when the file playback virtual board has reached the end of file and stops producing data.