### PR TITLE
Fix ganglion firmware v2 packet ordering

### DIFF
--- a/src/board_controller/openbci/ganglion_native.cpp
+++ b/src/board_controller/openbci/ganglion_native.cpp
@@ -474,16 +474,17 @@ void GanglionNative::read_data (
         package[i] = 0.0;
     }
 
-    if (data[0] <= 200)
+    if (data[0] <= 200 && size == 20)
     {
         if (firmware == 3)
         {
-            decompress_firmware_3 (data);
+            decompress_firmware_3 (data, package);
         }
         else if (firmware == 2)
         {
-            decompress_firmware_2 (data);
+            decompress_firmware_2 (data, package);
         }
+        delete[] package;
     }
     else if ((data[0] > 200) && (data[0] < 206))
     {
@@ -556,6 +557,58 @@ void GanglionNative::read_data (
         delete[] package;
         return;
     }
+}
+
+void GanglionNative::decompress_firmware_3 (uint8_t *data, double *package)
+{
+    int bits_per_num = 0;
+    unsigned char package_bits[160] = {0}; // 20 * 8
+    for (int i = 0; i < 20; i++)
+    {
+        uchar_to_bits (data[i], package_bits + i * 8);
+    }
+
+    // 18 bit compression, sends 17 MSBs + sign bit of 24-bit sample
+    if (data[0] >= 0 && data[0] < 100)
+    {
+        int last_digit = data[0] % 10;
+        switch (last_digit)
+        {
+            // accel data is signed, so we must cast it to signed char
+            // swap x and z, and invert z to convert to standard coordinate space.
+            case 0:
+                temp_data.accel_z = -accel_scale * (char)data[19];
+                break;
+            case 1:
+                temp_data.accel_y = accel_scale * (char)data[19];
+                break;
+            case 2:
+                temp_data.accel_x = accel_scale * (char)data[19];
+                break;
+            default:
+                break;
+        }
+        bits_per_num = 18;
+    }
+    else if (data[0] >= 100 && data[0] < 200)
+    {
+        bits_per_num = 19;
+    }
+
+    // handle compressed data for 18 or 19 bits
+    for (int i = 8, counter = 0; i < bits_per_num * 8; i += bits_per_num, counter++)
+    {
+        if (bits_per_num == 18)
+        {
+            temp_data.last_data[counter] =
+                (float)(cast_ganglion_bits_to_int32<18> (package_bits + i) << 6);
+        }
+        else
+        {
+            temp_data.last_data[counter] =
+                (float)(cast_ganglion_bits_to_int32<19> (package_bits + i) << 5);
+        }
+    }
 
     // add first encoded package
     package[board_descr["default"]["package_num_channel"].get<int> ()] = data[0];
@@ -583,62 +636,9 @@ void GanglionNative::read_data (
         eeg_scale * temp_data.last_data[7];
     package[board_descr["default"]["timestamp_channel"].get<int> ()] = get_timestamp ();
     push_package (package);
-    delete[] package;
 }
 
-void GanglionNative::decompress_firmware_3 (uint8_t *data)
-{
-    int bits_per_num = 0;
-    unsigned char package_bits[160] = {0}; // 20 * 8
-    for (int i = 0; i < 20; i++)
-    {
-        uchar_to_bits (data[i], package_bits + i * 8);
-    }
-
-    // 18 bit compression, sends 17 MSBs + sign bit of 24-bit sample
-    if ((data[0] >= 0) && (data[0] < 100))
-    {
-        int last_digit = data[0] % 10;
-        switch (last_digit)
-        {
-            // accel data is signed, so we must cast it to signed char
-            // swap x and z, and invert z to convert to standard coordinate space.
-            case 0:
-                temp_data.accel_z = -accel_scale * (char)data[19];
-                break;
-            case 1:
-                temp_data.accel_y = accel_scale * (char)data[19];
-                break;
-            case 2:
-                temp_data.accel_x = accel_scale * (char)data[19];
-                break;
-            default:
-                break;
-        }
-        bits_per_num = 18;
-    }
-    else if ((data[0] >= 100) && (data[0] < 200))
-    {
-        bits_per_num = 19;
-    }
-
-    // handle compressed data for 18 or 19 bits
-    for (int i = 8, counter = 0; i < bits_per_num * 8; i += bits_per_num, counter++)
-    {
-        if (bits_per_num == 18)
-        {
-            temp_data.last_data[counter] =
-                (float)(cast_ganglion_bits_to_int32<18> (package_bits + i) << 6);
-        }
-        else
-        {
-            temp_data.last_data[counter] =
-                (float)(cast_ganglion_bits_to_int32<19> (package_bits + i) << 5);
-        }
-    }
-}
-
-void GanglionNative::decompress_firmware_2 (uint8_t *data)
+void GanglionNative::decompress_firmware_2 (uint8_t *data, double *package)
 {
     int bits_per_num = 0;
     unsigned char package_bits[160] = {0}; // 20 * 8
@@ -663,9 +663,26 @@ void GanglionNative::decompress_firmware_2 (uint8_t *data)
         temp_data.last_data[5] = (float)cast_24bit_to_int32 (data + 4);
         temp_data.last_data[6] = (float)cast_24bit_to_int32 (data + 7);
         temp_data.last_data[7] = (float)cast_24bit_to_int32 (data + 10);
+
+        // scale new packet and insert into result
+        package[board_descr["default"]["package_num_channel"].get<int> ()] = 0.;
+        package[board_descr["default"]["eeg_channels"][0].get<int> ()] =
+            eeg_scale * temp_data.last_data[4];
+        package[board_descr["default"]["eeg_channels"][1].get<int> ()] =
+            eeg_scale * temp_data.last_data[5];
+        package[board_descr["default"]["eeg_channels"][2].get<int> ()] =
+            eeg_scale * temp_data.last_data[6];
+        package[board_descr["default"]["eeg_channels"][3].get<int> ()] =
+            eeg_scale * temp_data.last_data[7];
+        package[board_descr["default"]["accel_channels"][0].get<int> ()] = temp_data.accel_x;
+        package[board_descr["default"]["accel_channels"][1].get<int> ()] = temp_data.accel_y;
+        package[board_descr["default"]["accel_channels"][2].get<int> ()] = temp_data.accel_z;
+        package[board_descr["default"]["timestamp_channel"].get<int> ()] = get_timestamp ();
+        push_package (package);
+        return;
     }
     // 18 bit compression, sends delta from previous value instead of real value!
-    else if ((data[0] >= 1) && (data[0] <= 100))
+    if (data[0] >= 1 && data[0] <= 100)
     {
         int last_digit = data[0] % 10;
         switch (last_digit)
@@ -686,7 +703,7 @@ void GanglionNative::decompress_firmware_2 (uint8_t *data)
         }
         bits_per_num = 18;
     }
-    else if ((data[0] >= 101) && (data[0] <= 200))
+    else if (data[0] >= 101 && data[0] <= 200)
     {
         bits_per_num = 19;
     }
@@ -715,4 +732,31 @@ void GanglionNative::decompress_firmware_2 (uint8_t *data)
     {
         temp_data.last_data[i] = temp_data.last_data[i - 4] - delta[i];
     }
+
+    // add first encoded package
+    package[board_descr["default"]["package_num_channel"].get<int> ()] = data[0];
+    package[board_descr["default"]["eeg_channels"][0].get<int> ()] =
+        eeg_scale * temp_data.last_data[0];
+    package[board_descr["default"]["eeg_channels"][1].get<int> ()] =
+        eeg_scale * temp_data.last_data[1];
+    package[board_descr["default"]["eeg_channels"][2].get<int> ()] =
+        eeg_scale * temp_data.last_data[2];
+    package[board_descr["default"]["eeg_channels"][3].get<int> ()] =
+        eeg_scale * temp_data.last_data[3];
+    package[board_descr["default"]["accel_channels"][0].get<int> ()] = temp_data.accel_x;
+    package[board_descr["default"]["accel_channels"][1].get<int> ()] = temp_data.accel_y;
+    package[board_descr["default"]["accel_channels"][2].get<int> ()] = temp_data.accel_z;
+    package[board_descr["default"]["timestamp_channel"].get<int> ()] = get_timestamp ();
+    push_package (package);
+    // add second package
+    package[board_descr["default"]["eeg_channels"][0].get<int> ()] =
+        eeg_scale * temp_data.last_data[4];
+    package[board_descr["default"]["eeg_channels"][1].get<int> ()] =
+        eeg_scale * temp_data.last_data[5];
+    package[board_descr["default"]["eeg_channels"][2].get<int> ()] =
+        eeg_scale * temp_data.last_data[6];
+    package[board_descr["default"]["eeg_channels"][3].get<int> ()] =
+        eeg_scale * temp_data.last_data[7];
+    package[board_descr["default"]["timestamp_channel"].get<int> ()] = get_timestamp ();
+    push_package (package);
 }

--- a/src/board_controller/openbci/inc/ganglion.h
+++ b/src/board_controller/openbci/inc/ganglion.h
@@ -63,8 +63,8 @@ public:
     int release_session ();
     int config_board (std::string config, std::string &response);
 
-    void decompress_firmware_3 (
-        struct GanglionLib::GanglionData *data, float *last_data, double *acceleration);
-    void decompress_firmware_2 (
-        struct GanglionLib::GanglionData *data, float *last_data, double *acceleration);
+    void decompress_firmware_3 (struct GanglionLib::GanglionData *data, float *last_data,
+        double *acceleration, double *package);
+    void decompress_firmware_2 (struct GanglionLib::GanglionData *data, float *last_data,
+        double *acceleration, double *package);
 };

--- a/src/board_controller/openbci/inc/ganglion_native.h
+++ b/src/board_controller/openbci/inc/ganglion_native.h
@@ -115,6 +115,6 @@ protected:
     double const accel_scale = 0.016f;
     double const eeg_scale = (1.2f * 1000000) / (8388607.0f * 1.5f * 51.0f);
 
-    void decompress_firmware_3 (uint8_t *data);
-    void decompress_firmware_2 (uint8_t *data);
+    void decompress_firmware_3 (uint8_t *data, double *package);
+    void decompress_firmware_2 (uint8_t *data, double *package);
 };


### PR DESCRIPTION
There was a problem with the packet ordering for the Ganglion firmware v2 decompression. In this firmware, a raw packet is sent every 100Hz to "reset" the delta compression. The previous implementation wrote this raw packet in the wrong order and left the sample package where it should have been unchanged. This didn't change the data stream much (it just wrote the same sample twice), but it would cause the same package index to be written twice. This is an issue for downstream clients that use the package index to check if samples have been lost over the bluetooth connection.