### PR TITLE
Fixed confliciting name

### DIFF
--- a/src/utils/inc/brainflow_array.h
+++ b/src/utils/inc/brainflow_array.h
@@ -448,9 +448,9 @@ public:
     }
 
     /// fill already preallocated buffer
-    void fill (T *ptr, int size)
+    void fill (T *ptr, int num)
     {
-        memcpy (origin, ptr, sizeof (T) * size);
+        memcpy (origin, ptr, sizeof (T) * num);
     }
 };
 


### PR DESCRIPTION
Running on MacOs with M2 chip, I was getting the following error while building due to conflict names:

<img width="1238" alt="Screenshot 2023-09-08 at 20 12 14" src="https://github.com/brainflow-dev/brainflow/assets/21221169/f652d74e-5d6b-43f0-98fc-3b15dd09c64a">

Since both `size` and `length` are taken I opted for `num`, but feel free to suggest a different name.