### PR TITLE
Fix requirements.txt for enophone example

### DIFF
--- a/python_package/examples/enophone/requirements.txt
+++ b/python_package/examples/enophone/requirements.txt
@@ -1,3 +1,6 @@
-scipy
-pyqtgraph
+PyQt5==5.15.7
+PyQt5-Qt5==5.15.2
+PyQt5-sip==12.11.0
+pyqtgraph==0.12.4
 brainflow
+scipy==1.11.4


### PR DESCRIPTION
[enophone_streaming.py](https://github.com/brainflow-dev/brainflow/blob/master/python_package/examples/enophone/enophone_streaming.py) presented runtime errors due to use of deprecated API.

I copied the values from [plot_real_time](https://github.com/brainflow-dev/brainflow/blob/e13abf8e5c800bcb539e4b75439acd435b81d6ed/python_package/examples/plot_real_time/requirements.txt) and added the latest release of scipy.

Tested with Python 3.11.1 on Windows 11