### PR TITLE
Tiny fixups

### DIFF
--- a/src/board_controller/build.cmake
+++ b/src/board_controller/build.cmake
@@ -83,7 +83,7 @@ SET (BOARD_CONTROLLER_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/board_controller/brainalive/brainalive.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/board_controller/emotibit/emotibit.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/board_controller/ntl/ntl_wifi.cpp
-    ${CMAKE_HOME_DIRECTORY}/src/board_controller/aavaa/aavaa_v3.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/board_controller/aavaa/aavaa_v3.cpp
 )
 
 include (${CMAKE_CURRENT_SOURCE_DIR}/src/board_controller/ant_neuro/build.cmake)
@@ -139,7 +139,7 @@ target_include_directories (
     ${CMAKE_CURRENT_SOURCE_DIR}/src/board_controller/mentalab/inc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/board_controller/emotibit/inc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/board_controller/ntl/inc
-    ${CMAKE_HOME_DIRECTORY}/src/board_controller/aavaa/inc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/board_controller/aavaa/inc
 )
 
 target_compile_definitions(${BOARD_CONTROLLER_NAME} PRIVATE NOMINMAX BRAINFLOW_VERSION=${BRAINFLOW_VERSION})

--- a/third_party/kissfft/CMakeLists.txt
+++ b/third_party/kissfft/CMakeLists.txt
@@ -98,7 +98,7 @@ endif()
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     add_compile_options(-ffast-math -fomit-frame-pointer
         -W -Wall -Wcast-align -Wcast-qual -Wshadow -Wwrite-strings
-        "$<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes;-Wmissing-prototypes;-Wnested-externs;-Wbad-function-cast>")
+        $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes;-Wmissing-prototypes;-Wnested-externs;-Wbad-function-cast>)
 endif()
 
 #

--- a/third_party/kissfft/build.cmake
+++ b/third_party/kissfft/build.cmake
@@ -88,8 +88,8 @@ target_include_directories(kissfft PUBLIC
 
 if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
     target_compile_options(kissfft PRIVATE
-        "$<$<COMPILE_LANGUAGE:CXX>:-ffast-math -fomit-frame-pointer -W -Wall -Wcast-align -Wcast-qual -Wwrite-strings>"
-        "$<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes;-Wmissing-prototypes;-Wnested-externs;-Wbad-function-cast>")
+        $<$<COMPILE_LANGUAGE:CXX>:-ffast-math -fomit-frame-pointer -W -Wall -Wcast-align -Wcast-qual -Wwrite-strings>
+        $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes;-Wmissing-prototypes;-Wnested-externs;-Wbad-function-cast>)
 endif()
 
 #


### PR DESCRIPTION
Correctly adds corrections to improve correctness.

Allows building BrainFlow as a submodule.