### PR TITLE
Fix EEG names for Muse 2, Muse S, Muse 2016

### DIFF
--- a/src/board_controller/brainflow_boards.cpp
+++ b/src/board_controller/brainflow_boards.cpp
@@ -412,7 +412,7 @@ BrainFlowBoards::BrainFlowBoards()
         {"package_num_channel", 0},
         {"num_rows", 8},
         {"eeg_channels", {1, 2, 3, 4}},
-        {"eeg_names", "TP9,Fp1,Fp2,TP10"},
+        {"eeg_names", "TP9,AF7,AF8,TP10"},
         {"other_channels", {5}}
     };
     brainflow_boards_json["boards"]["21"]["auxiliary"] =
@@ -445,7 +445,7 @@ BrainFlowBoards::BrainFlowBoards()
         {"package_num_channel", 0},
         {"num_rows", 8},
         {"eeg_channels", {1, 2, 3, 4}},
-        {"eeg_names", "TP9,Fp1,Fp2,TP10"},
+        {"eeg_names", "TP9,AF7,AF8,TP10"},
         {"other_channels", {5}}
     };
     brainflow_boards_json["boards"]["22"]["auxiliary"] =
@@ -652,7 +652,7 @@ BrainFlowBoards::BrainFlowBoards()
         {"package_num_channel", 0},
         {"num_rows", 8},
         {"eeg_channels", {1, 2, 3, 4}},
-        {"eeg_names", "TP9,Fp1,Fp2,TP10"},
+        {"eeg_names", "TP9,AF7,AF8,TP10"},
         {"other_channels", {5}}
     };
     brainflow_boards_json["boards"]["38"]["auxiliary"] =
@@ -685,7 +685,7 @@ BrainFlowBoards::BrainFlowBoards()
         {"package_num_channel", 0},
         {"num_rows", 8},
         {"eeg_channels", {1, 2, 3, 4}},
-        {"eeg_names", "TP9,Fp1,Fp2,TP10"},
+        {"eeg_names", "TP9,AF7,AF8,TP10"},
         {"other_channels", {5}}
     };
     brainflow_boards_json["boards"]["39"]["auxiliary"] =
@@ -731,7 +731,7 @@ BrainFlowBoards::BrainFlowBoards()
         {"package_num_channel", 0},
         {"num_rows", 7},
         {"eeg_channels", {1, 2, 3, 4}},
-        {"eeg_names", "TP9,Fp1,Fp2,TP10"}
+        {"eeg_names", "TP9,AF7,AF8,TP10"}
     };
     brainflow_boards_json["boards"]["41"]["auxiliary"] =
     {
@@ -753,7 +753,7 @@ BrainFlowBoards::BrainFlowBoards()
         {"package_num_channel", 0},
         {"num_rows", 7},
         {"eeg_channels", {1, 2, 3, 4}},
-        {"eeg_names", "TP9,Fp1,Fp2,TP10"},
+        {"eeg_names", "TP9,AF7,AF8,TP10"},
     };
     brainflow_boards_json["boards"]["42"]["auxiliary"] =
     {


### PR DESCRIPTION
### Description of Changes
I noticed that the `eeg_names` for the Muse 2 I am using were incorrect. Upon checking, it seems that the names have changed.

Original: TP9, Fp1, Fp2, TP10
Updated: TP9, AF7, AF8, TP10

### Reference
https://github.com/brainflow-dev/brainflow/blob/master/src/board_controller/muse/inc/muse_constants.h
```
#define MUSE_GATT_ATTR_TP9 "273e0003-4c4d-454d-96be-f03bac821358"
#define MUSE_GATT_ATTR_AF7 "273e0004-4c4d-454d-96be-f03bac821358"
#define MUSE_GATT_ATTR_AF8 "273e0005-4c4d-454d-96be-f03bac821358"
#define MUSE_GATT_ATTR_TP10 "273e0006-4c4d-454d-96be-f03bac821358"
```
![image](https://github.com/user-attachments/assets/95a02ea4-a9c2-4434-9039-bbb3a7dbb5e3)