### PR TITLE
Fix UTF-8 encoding problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ option (BUILD_PERIPHERY "BUILD_PERIPHERY" OFF)
 include (${CMAKE_CURRENT_SOURCE_DIR}/cmake/macros.cmake)
 configure_msvc_runtime ()
 
+add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
+add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+
 if (WARNINGS_AS_ERRORS)
     if (MSVC)
         add_compile_options (/WX)


### PR DESCRIPTION
`Traceback (most recent call last):
  File "C:\Users\cheongpark\brainflow\tools\build.py", line 309, in <module>
    main()
  File "C:\Users\cheongpark\brainflow\tools\build.py", line 305, in main
    build(args)
  File "C:\Users\cheongpark\brainflow\tools\build.py", line 290, in build
    run_command(cmd_build, cwd=args.build_dir)
  File "C:\Users\cheongpark\brainflow\tools\build.py", line 22, in run_command
    raise ValueError('Process finished with error code %d' % p.returncode)
ValueError: Process finished with error code 1`

When building with the `--ble` option on Windows in languages such as Korean or Japanese, an error like the one above occurs. This error seems to happen if the "Beta: Use Unicode UTF-8 for worldwide language support" option is not enabled. Enabling the committed option seems to resolve the issue for now.