### PR TITLE
Fix PyQT Error

### DIFF
--- a/python_package/examples/enophone/enophone_streaming.py
+++ b/python_package/examples/enophone/enophone_streaming.py
@@ -3,7 +3,7 @@ import logging
 
 import pyqtgraph as pg
 from brainflow.board_shim import BoardShim, BrainFlowInputParams, BoardIds
-from pyqtgraph.Qt import QtGui, QtCore
+from pyqtgraph.Qt import QtWidgets, QtCore
 
 import enotools
 
@@ -19,14 +19,14 @@ class Graph:
         self.num_points = self.window_size * self.sampling_rate
         self.plot_names = ['Quality A2', 'Quality A1', 'Quality C4', 'Quality C3']
         self.mains = None
-        self.app = QtGui.QApplication([])
-        self.win = pg.GraphicsWindow(title='Enophone Live Streaming', size=(800, 600))
+        self.app = QtWidgets.QApplication([])
+        self.win = pg.GraphicsLayoutWidget(title='Enophone Live Streaming', size=(800, 600), show=True)
         self._init_timeseries()
 
         timer = QtCore.QTimer()
         timer.timeout.connect(self.update)
         timer.start(self.update_speed_ms)
-        QtGui.QApplication.instance().exec_()
+        QtWidgets.QApplication.instance().exec()
 
     def _init_timeseries(self):
         self.plots = list()

--- a/python_package/examples/plot_real_time/plot_real_time.py
+++ b/python_package/examples/plot_real_time/plot_real_time.py
@@ -4,7 +4,7 @@ import logging
 import pyqtgraph as pg
 from brainflow.board_shim import BoardShim, BrainFlowInputParams, BoardIds
 from brainflow.data_filter import DataFilter, FilterTypes, WindowOperations, DetrendOperations
-from pyqtgraph.Qt import QtGui, QtCore
+from pyqtgraph.Qt import QtWidgets, QtCore
 
 
 class Graph:
@@ -20,8 +20,8 @@ class Graph:
         self.window_size = 4
         self.num_points = self.window_size * self.sampling_rate
 
-        self.app = QtGui.QApplication([])
-        self.win = pg.GraphicsWindow(title='BrainFlow Plot', size=(800, 600))
+        self.app = QtWidgets.QApplication([])
+        self.win = pg.GraphicsLayoutWidget(title='BrainFlow Plot', size=(800, 600), show=True)
 
         self._init_pens()
         self._init_timeseries()
@@ -31,7 +31,7 @@ class Graph:
         timer = QtCore.QTimer()
         timer.timeout.connect(self.update)
         timer.start(self.update_speed_ms)
-        QtGui.QApplication.instance().exec_()
+        QtWidgets.QApplication.instance().exec()
 
     def _init_pens(self):
         self.pens = list()

--- a/python_package/examples/plot_real_time/plot_real_time_min.py
+++ b/python_package/examples/plot_real_time/plot_real_time_min.py
@@ -4,7 +4,7 @@ import logging
 import pyqtgraph as pg
 from brainflow.board_shim import BoardShim, BrainFlowInputParams, BoardIds
 from brainflow.data_filter import DataFilter, FilterTypes, DetrendOperations
-from pyqtgraph.Qt import QtGui, QtCore
+from pyqtgraph.Qt import QtWidgets, QtCore
 
 
 class Graph:
@@ -17,15 +17,15 @@ class Graph:
         self.window_size = 4
         self.num_points = self.window_size * self.sampling_rate
 
-        self.app = QtGui.QApplication([])
-        self.win = pg.GraphicsWindow(title='BrainFlow Plot', size=(800, 600))
+        self.app = QtWidgets.QApplication([])
+        self.win = pg.GraphicsLayoutWidget(title='BrainFlow Plot', size=(800, 600), show=True)
 
         self._init_timeseries()
 
         timer = QtCore.QTimer()
         timer.timeout.connect(self.update)
         timer.start(self.update_speed_ms)
-        QtGui.QApplication.instance().exec_()
+        QtWidgets.QApplication.instance().exec()
 
     def _init_timeseries(self):
         self.plots = list()


### PR DESCRIPTION
Fixed PyQt and PyQtGraph compatibility issues:

1. QtGui.QApplication -> QtWidgets.QApplication
   **Error**: AttributeError: module 'pyqtgraph.Qt.QtGui' has no attribute 'QApplication'
   **Fix**: Updated import to use QtWidgets which is the correct module for QApplication in newer Qt versions

2. pg.GraphicsWindow -> pg.GraphicsLayoutWidget
   **Error**: AttributeError: module 'pyqtgraph' has no attribute 'GraphicsWindow'
   **Fix**: GraphicsWindow was deprecated and replaced with GraphicsLayoutWidget in newer PyQtGraph versions

3. Added "show=True" parameter
   **Fix**: Explicitly set window visibility when creating GraphicsLayoutWidget