### PR TITLE
ANT Neuro SDK functions

### DIFF
--- a/python_package/examples/tests/eego_impedances_and_eeg.py
+++ b/python_package/examples/tests/eego_impedances_and_eeg.py
@@ -7,6 +7,15 @@ if __name__ == '__main__':
     board = BoardShim(BoardIds.ANT_NEURO_EE_411_BOARD, params)  # 8 channel amplifier
     board.prepare_session()
 
+    # Get amplifier info
+    print(f"get_type: {board.config_board('get_type')}")
+    print(f"get_firmware_version: {board.config_board('get_firmware_version')}")
+    print(f"get_serial_number: {board.config_board('get_serial_number')}")
+    print(f"get_sampling_rates_available: {board.config_board('get_sampling_rates_available')}")
+    print(f"get_reference_ranges_available: {board.config_board('get_reference_ranges_available')}")
+    print(f"get_bipolar_ranges_available: {board.config_board('get_bipolar_ranges_available')}")
+    print(f"get_power_state: {board.config_board('get_power_state')}")
+
     # Get impedance data
     board.config_board('impedance_mode:1')
     board.start_stream()

--- a/python_package/examples/tests/eego_impedances_and_eeg.py
+++ b/python_package/examples/tests/eego_impedances_and_eeg.py
@@ -1,4 +1,5 @@
 import time
+import json
 
 from brainflow.board_shim import BoardShim, BrainFlowInputParams, BoardIds
 
@@ -8,13 +9,9 @@ if __name__ == '__main__':
     board.prepare_session()
 
     # Get amplifier info
-    print(f"get_type: {board.config_board('get_type')}")
-    print(f"get_firmware_version: {board.config_board('get_firmware_version')}")
-    print(f"get_serial_number: {board.config_board('get_serial_number')}")
-    print(f"get_sampling_rates_available: {board.config_board('get_sampling_rates_available')}")
-    print(f"get_reference_ranges_available: {board.config_board('get_reference_ranges_available')}")
-    print(f"get_bipolar_ranges_available: {board.config_board('get_bipolar_ranges_available')}")
-    print(f"get_power_state: {board.config_board('get_power_state')}")
+    info = json.loads(board.config_board('get_info'))
+    for key, value in info.items():
+        print(f" - {key}: {value}")
 
     # Get impedance data
     board.config_board('impedance_mode:1')

--- a/src/board_controller/ant_neuro/ant_neuro.cpp
+++ b/src/board_controller/ant_neuro/ant_neuro.cpp
@@ -508,7 +508,7 @@ int AntNeuroBoard::config_board (std::string config, std::string &response)
         for (int i = 0; i < reference_ranges.size (); ++i)
         {
             oss << reference_ranges[i];
-            if (i != reference_ranges.size() - 1)
+            if (i != reference_ranges.size () - 1)
             {
                 oss << ",";
             }

--- a/src/board_controller/ant_neuro/ant_neuro.cpp
+++ b/src/board_controller/ant_neuro/ant_neuro.cpp
@@ -11,8 +11,8 @@
 #include <unistd.h>
 #endif
 
-#include <sstream>
 #include <iterator>
+#include <sstream>
 
 #include <algorithm>
 #include <chrono>
@@ -490,8 +490,8 @@ int AntNeuroBoard::config_board (std::string config, std::string &response)
     }
     else if (config == get_firmware_version)
     {
-        int version = amp->getFirmwareVersion();
-        response = std::to_string(version);
+        int version = amp->getFirmwareVersion ();
+        response = std::to_string (version);
         return (int)BrainFlowExitCodes::STATUS_OK;
     }
     else if (config == get_serial_number)
@@ -501,38 +501,41 @@ int AntNeuroBoard::config_board (std::string config, std::string &response)
     }
     else if (config == get_sampling_rates_available)
     {
-        std::vector<int> sampling_rates = amp->getSamplingRatesAvailable();
+        std::vector<int> sampling_rates = amp->getSamplingRatesAvailable ();
         std::ostringstream result;
-        if (!sampling_rates.empty()) 
+        if (!sampling_rates.empty ())
         {
-            std::copy(sampling_rates.begin(), sampling_rates.end() - 1, std::ostream_iterator<int>(result, ","));
-            result << sampling_rates.back();  // no trailing comma
+            std::copy (sampling_rates.begin (), sampling_rates.end () - 1,
+                std::ostream_iterator<int> (result, ","));
+            result << sampling_rates.back (); // no trailing comma
         }
-        response = result.str();
+        response = result.str ();
         return (int)BrainFlowExitCodes::STATUS_OK;
     }
     else if (config == get_reference_ranges_available)
     {
-        std::vector<double> reference_ranges = amp->getReferenceRangesAvailable();
+        std::vector<double> reference_ranges = amp->getReferenceRangesAvailable ();
         std::ostringstream result;
-        if (!reference_ranges.empty()) 
+        if (!reference_ranges.empty ())
         {
-            std::copy(reference_ranges.begin(), reference_ranges.end() - 1, std::ostream_iterator<double>(result, ","));
-            result << reference_ranges.back();  // no trailing comma
+            std::copy (reference_ranges.begin (), reference_ranges.end () - 1,
+                std::ostream_iterator<double> (result, ","));
+            result << reference_ranges.back (); // no trailing comma
         }
-        response = result.str();
+        response = result.str ();
         return (int)BrainFlowExitCodes::STATUS_OK;
     }
     else if (config == get_bipolar_ranges_available)
     {
-        std::vector<double> bipolar_ranges = amp->getBipolarRangesAvailable();
+        std::vector<double> bipolar_ranges = amp->getBipolarRangesAvailable ();
         std::ostringstream result;
-        if (!bipolar_ranges.empty()) 
+        if (!bipolar_ranges.empty ())
         {
-            std::copy(bipolar_ranges.begin(), bipolar_ranges.end() - 1, std::ostream_iterator<double>(result, ","));
-            result << bipolar_ranges.back();  // no trailing comma
+            std::copy (bipolar_ranges.begin (), bipolar_ranges.end () - 1,
+                std::ostream_iterator<double> (result, ","));
+            result << bipolar_ranges.back (); // no trailing comma
         }
-        response = result.str();
+        response = result.str ();
         return (int)BrainFlowExitCodes::STATUS_OK;
     }
     else if (config == get_power_state)
@@ -542,7 +545,7 @@ int AntNeuroBoard::config_board (std::string config, std::string &response)
         oss << "is_powered: " << power_state.is_powered
             << ", is_charging: " << power_state.is_charging
             << ", charging_level: " << power_state.charging_level;
-        response = oss.str();
+        response = oss.str ();
 
         return (int)BrainFlowExitCodes::STATUS_OK;
     }

--- a/src/board_controller/ant_neuro/ant_neuro.cpp
+++ b/src/board_controller/ant_neuro/ant_neuro.cpp
@@ -11,7 +11,6 @@
 #include <unistd.h>
 #endif
 
-#include <iterator>
 #include <sstream>
 
 #include <algorithm>
@@ -492,7 +491,7 @@ int AntNeuroBoard::config_board (std::string config, std::string &response)
         // getSamplingRatesAvailable
         std::vector<int> sampling_rates = amp->getSamplingRatesAvailable ();
         oss << "\"sampling_rates\":[";
-        for (int i = 0; i < sampling_rates.size (); ++i)
+        for (size_t i = 0; i < sampling_rates.size (); ++i)
         {
             oss << sampling_rates[i];
             if (i != sampling_rates.size () - 1)
@@ -505,7 +504,7 @@ int AntNeuroBoard::config_board (std::string config, std::string &response)
         // getReferenceRangesAvailable
         std::vector<double> reference_ranges = amp->getReferenceRangesAvailable ();
         oss << "\"reference_ranges\":[";
-        for (int i = 0; i < reference_ranges.size (); ++i)
+        for (size_t i = 0; i < reference_ranges.size (); ++i)
         {
             oss << reference_ranges[i];
             if (i != reference_ranges.size () - 1)
@@ -518,7 +517,7 @@ int AntNeuroBoard::config_board (std::string config, std::string &response)
         // getBipolarRangesAvailable
         std::vector<double> bipolar_ranges = amp->getBipolarRangesAvailable ();
         oss << "\"bipolar_ranges\":[";
-        for (int i = 0; i < bipolar_ranges.size (); ++i)
+        for (size_t i = 0; i < bipolar_ranges.size (); ++i)
         {
             oss << bipolar_ranges[i];
             if (i != bipolar_ranges.size () - 1)

--- a/src/board_controller/ant_neuro/ant_neuro.cpp
+++ b/src/board_controller/ant_neuro/ant_neuro.cpp
@@ -483,11 +483,8 @@ int AntNeuroBoard::config_board (std::string config, std::string &response)
         j["reference_ranges"] = amp->getReferenceRangesAvailable ();
         j["bipolar_ranges"] = amp->getBipolarRangesAvailable ();
         amplifier::power_state ps = amp->getPowerState ();
-        j["power_state"] = {
-            {"is_powered", ps.is_powered},
-            {"is_charging", ps.is_charging},
-            {"charging_level", ps.charging_level}
-        };
+        j["power_state"] = {{"is_powered", ps.is_powered}, {"is_charging", ps.is_charging},
+            {"charging_level", ps.charging_level}};
         response = j.dump ();
         return (int)BrainFlowExitCodes::STATUS_OK;
     }

--- a/src/board_controller/ant_neuro/ant_neuro.cpp
+++ b/src/board_controller/ant_neuro/ant_neuro.cpp
@@ -529,7 +529,7 @@ int AntNeuroBoard::config_board (std::string config, std::string &response)
         std::ostringstream result;
         if (!bipolar_ranges.empty()) 
         {
-            std::copy(bipolar_ranges.begin(), bipolar_ranges.end() - 1, std::ostream_iterator<int>(result, ","));
+            std::copy(bipolar_ranges.begin(), bipolar_ranges.end() - 1, std::ostream_iterator<double>(result, ","));
             result << bipolar_ranges.back();  // no trailing comma
         }
         response = result.str();


### PR DESCRIPTION
Added ANT SDK info as custom config_board function `"get_info"`:

```python
board.config_board("get_info")
```
would return (for example):
```json
{
    "type": "EE411",
    "firmware_version": 12345,
    "serial_number": "424242",
    "sampling_rates": [500,512,1000,1024,2000,2048],
    "reference_ranges": [1,0.75,0.15],
    "bipolar_ranges": [1,0.75,0.15],
    "power_state": {
        "is_powered": 1,
        "is_charging": 0,
        "charging_level": -1
    }
}
```