### PR TITLE
Fix Node.js native library lookup in packaged Electron apps

### DIFF
--- a/nodejs_package/brainflow/board_shim.ts
+++ b/nodejs_package/brainflow/board_shim.ts
@@ -12,6 +12,7 @@ import {
     LogLevels,
 } from './brainflow.types';
 import {BoardControllerCLikeFunctions as CLike, BoardControllerFunctions} from './functions.types';
+import {resolveLibPath} from './lib_path';
 
 export class BrainFlowInputParams
 {
@@ -60,7 +61,7 @@ class BoardControllerDLL extends BoardControllerFunctions
     private constructor()
     {
         super ();
-        this.libPath = `${__dirname}/../brainflow/lib`;
+        this.libPath = resolveLibPath();
         this.dllPath = this.getDLLPath();
         this.lib = this.getLib();
 

--- a/nodejs_package/brainflow/data_filter.ts
+++ b/nodejs_package/brainflow/data_filter.ts
@@ -19,6 +19,7 @@ import {
 } from './brainflow.types';
 import {complex} from './complex';
 import {DataHandlerCLikeFunctions as CLike, DataHandlerFunctions} from './functions.types';
+import {resolveLibPath} from './lib_path';
 
 class DataHandlerDLL extends DataHandlerFunctions
 {
@@ -32,7 +33,7 @@ class DataHandlerDLL extends DataHandlerFunctions
     private constructor()
     {
         super ();
-        this.libPath = `${__dirname}/../brainflow/lib`;
+        this.libPath = resolveLibPath();
         this.dllPath = this.getDLLPath();
         this.lib = this.getLib();
 

--- a/nodejs_package/brainflow/lib_path.ts
+++ b/nodejs_package/brainflow/lib_path.ts
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import path from 'path';
+
+const appAsarRegexp = new RegExp(`\\${path.sep}app\\.asar\\${path.sep}`, 'g');
+
+export function resolveLibPath(): string
+{
+    const defaultLibPath = path.resolve(__dirname, '..', 'brainflow', 'lib');
+    const electronProcess = process as NodeJS.Process & {resourcesPath?: string};
+    const searchRoots = [
+        __dirname,
+        __dirname.replace(appAsarRegexp, `${path.sep}app.asar.unpacked${path.sep}`),
+        typeof electronProcess.resourcesPath === 'string' ? electronProcess.resourcesPath : '',
+    ].filter(Boolean);
+
+    const libPathCandidates = [
+        defaultLibPath,
+        ...searchRoots.flatMap((root) => [
+            path.resolve(root, '..', 'brainflow', 'lib'),
+            path.resolve(root, '..', 'node_modules', 'brainflow', 'brainflow', 'lib'),
+            path.resolve(root, 'node_modules', 'brainflow', 'brainflow', 'lib'),
+            path.resolve(root, 'app.asar.unpacked', 'node_modules', 'brainflow', 'brainflow', 'lib'),
+        ]),
+    ];
+
+    const existingPath = libPathCandidates.find((candidate) => fs.existsSync(candidate));
+    return existingPath || defaultLibPath;
+}

--- a/nodejs_package/brainflow/ml_model.ts
+++ b/nodejs_package/brainflow/ml_model.ts
@@ -11,6 +11,7 @@ import {
     LogLevels,
 } from './brainflow.types';
 import {MLModuleCLikeFunctions as CLike, MLModuleFunctions} from './functions.types';
+import {resolveLibPath} from './lib_path';
 
 export class BrainFlowModelParams
 {
@@ -52,7 +53,7 @@ class MLModuleDLL extends MLModuleFunctions
     private constructor()
     {
         super ();
-        this.libPath = `${__dirname}/../brainflow/lib`;
+        this.libPath = resolveLibPath();
         this.dllPath = this.getDLLPath();
         this.lib = this.getLib();
 


### PR DESCRIPTION
### Motivation
- Packaged Electron apps could not locate BrainFlow native libraries because the Node.js binding hardcoded `__dirname/../brainflow/lib`, which does not resolve inside `app.asar`/packaged layouts.
- Provide a robust resolution strategy that works both in normal Node.js installs and in Electron production builds (including `app.asar.unpacked` and `process.resourcesPath`).

### Description
- Add a shared resolver `resolveLibPath()` in `nodejs_package/brainflow/lib_path.ts` that builds candidate paths (including unpacked `app.asar` and common `node_modules` locations) and returns the first existing path or the original default as a fallback.
- Update the native loaders to use the new resolver by replacing the hardcoded path in `BoardShim`, `DataFilter`, and `MLModel` with `resolveLibPath()` in `nodejs_package/brainflow/board_shim.ts`, `nodejs_package/brainflow/data_filter.ts`, and `nodejs_package/brainflow/ml_model.ts`.
- Add a small TypeScript-friendly cast to safely access `process.resourcesPath` when present in Electron.

### Testing
- Ran `cd nodejs_package && npm run build` and the TypeScript build completed successfully after adding the `process` cast. ✅
- Ran `cd nodejs_package && npm run lint` and linting failed with many existing formatting issues unrelated to this change; the failure is due to pre-existing repository-wide `prettier` violations and not introduced by this patch. ❌
- Verified the added resolver file `nodejs_package/brainflow/lib_path.ts` and that the three loaders now call `resolveLibPath()` instead of using the hardcoded `__dirname` path.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c877ecb8832abd078ecb6a5f94a0)