### PR TITLE
Fix for Array index out of bounds

### DIFF
--- a/java_package/brainflow/src/main/java/brainflow/examples/EEGMetrics.java
+++ b/java_package/brainflow/src/main/java/brainflow/examples/EEGMetrics.java
@@ -49,41 +49,52 @@ public class EEGMetrics
         int board_id = -1;
         for (int i = 0; i < args.length; i++)
         {
-            if (args[i].equals ("--ip-address"))
+            String arg = args[i];
+            if (arg.equals ("--ip-address") || arg.equals ("--serial-port") || arg.equals ("--ip-port")
+                    || arg.equals ("--ip-protocol") || arg.equals ("--other-info") || arg.equals ("--board-id")
+                    || arg.equals ("--timeout") || arg.equals ("--serial-number") || arg.equals ("--file"))
             {
-                params.ip_address = args[i + 1];
-            }
-            if (args[i].equals ("--serial-port"))
-            {
-                params.serial_port = args[i + 1];
-            }
-            if (args[i].equals ("--ip-port"))
-            {
-                params.ip_port = Integer.parseInt (args[i + 1]);
-            }
-            if (args[i].equals ("--ip-protocol"))
-            {
-                params.ip_protocol = Integer.parseInt (args[i + 1]);
-            }
-            if (args[i].equals ("--other-info"))
-            {
-                params.other_info = args[i + 1];
-            }
-            if (args[i].equals ("--board-id"))
-            {
-                board_id = Integer.parseInt (args[i + 1]);
-            }
-            if (args[i].equals ("--timeout"))
-            {
-                params.timeout = Integer.parseInt (args[i + 1]);
-            }
-            if (args[i].equals ("--serial-number"))
-            {
-                params.serial_number = args[i + 1];
-            }
-            if (args[i].equals ("--file"))
-            {
-                params.file = args[i + 1];
+                if (i + 1 >= args.length)
+                {
+                    throw new IllegalArgumentException ("Missing value for argument: " + arg);
+                }
+                String value = args[++i];
+                if (arg.equals ("--ip-address"))
+                {
+                    params.ip_address = value;
+                }
+                else if (arg.equals ("--serial-port"))
+                {
+                    params.serial_port = value;
+                }
+                else if (arg.equals ("--ip-port"))
+                {
+                    params.ip_port = Integer.parseInt (value);
+                }
+                else if (arg.equals ("--ip-protocol"))
+                {
+                    params.ip_protocol = Integer.parseInt (value);
+                }
+                else if (arg.equals ("--other-info"))
+                {
+                    params.other_info = value;
+                }
+                else if (arg.equals ("--board-id"))
+                {
+                    board_id = Integer.parseInt (value);
+                }
+                else if (arg.equals ("--timeout"))
+                {
+                    params.timeout = Integer.parseInt (value);
+                }
+                else if (arg.equals ("--serial-number"))
+                {
+                    params.serial_number = value;
+                }
+                else if (arg.equals ("--file"))
+                {
+                    params.file = value;
+                }
             }
         }
         return board_id;


### PR DESCRIPTION
To fix this safely without changing intended behavior, validate that each option requiring a value actually has a following argument before accessing `args[i + 1]`. The best minimal fix is:

1. Detect recognized options.
2. Check `i + 1 >= args.length`; if true, throw a clear `IllegalArgumentException`.
3. Use the validated next argument once (`String value = args[++i];`) and assign/parse it per option.

This avoids out-of-bounds access, improves error messages, and keeps existing parsing semantics.  
All changes are in `java_package/brainflow/src/main/java/brainflow/examples/EEGMetrics.java`, inside `parse_args`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._