### PR TITLE
Fix for Array index out of bounds

### DIFF
--- a/java_package/brainflow/src/main/java/brainflow/examples/Markers.java
+++ b/java_package/brainflow/src/main/java/brainflow/examples/Markers.java
@@ -30,41 +30,60 @@ public class Markers
         int board_id = -1;
         for (int i = 0; i < args.length; i++)
         {
-            if (args[i].equals ("--ip-address"))
+            String arg = args[i];
+            boolean requires_value = arg.equals ("--ip-address") || arg.equals ("--serial-port")
+                    || arg.equals ("--ip-port") || arg.equals ("--ip-protocol")
+                    || arg.equals ("--other-info") || arg.equals ("--board-id")
+                    || arg.equals ("--timeout") || arg.equals ("--serial-number")
+                    || arg.equals ("--file");
+            if (requires_value && i + 1 >= args.length)
+            {
+                throw new IllegalArgumentException ("Missing value for argument: " + arg);
+            }
+            if (arg.equals ("--ip-address"))
             {
                 params.ip_address = args[i + 1];
+                i++;
             }
-            if (args[i].equals ("--serial-port"))
+            if (arg.equals ("--serial-port"))
             {
                 params.serial_port = args[i + 1];
+                i++;
             }
-            if (args[i].equals ("--ip-port"))
+            if (arg.equals ("--ip-port"))
             {
                 params.ip_port = Integer.parseInt (args[i + 1]);
+                i++;
             }
-            if (args[i].equals ("--ip-protocol"))
+            if (arg.equals ("--ip-protocol"))
             {
                 params.ip_protocol = Integer.parseInt (args[i + 1]);
+                i++;
             }
-            if (args[i].equals ("--other-info"))
+            if (arg.equals ("--other-info"))
             {
                 params.other_info = args[i + 1];
+                i++;
             }
-            if (args[i].equals ("--board-id"))
+            if (arg.equals ("--board-id"))
             {
                 board_id = Integer.parseInt (args[i + 1]);
+                i++;
             }
-            if (args[i].equals ("--timeout"))
+            if (arg.equals ("--timeout"))
             {
                 params.timeout = Integer.parseInt (args[i + 1]);
+                i++;
             }
-            if (args[i].equals ("--serial-number"))
+            if (arg.equals ("--serial-number"))
             {
                 params.serial_number = args[i + 1];
+                i++;
             }
-            if (args[i].equals ("--file"))
+            if (arg.equals ("--file"))
             {
                 params.file = args[i + 1];
+                i++;
             }
         }
         return board_id;


### PR DESCRIPTION
To fix this safely without changing intended behavior, validate that an option requiring a value actually has a following token before reading `args[i + 1]`. The best approach here is to add a guard at the top of the loop: when `args[i]` is one of the known value-taking flags and `i + 1 >= args.length`, throw an `IllegalArgumentException` with a clear message. Then, after consuming a value, increment `i` (`i++`) so the value token is not reprocessed as another flag.

In `java_package/brainflow/src/main/java/brainflow/examples/Markers.java`, update `parse_args` loop body (lines 31–69 region) to:
- Capture `args[i]` into a local `arg`.
- Check whether `arg` is a known flag requiring a value and whether a value exists.
- Use `arg` in comparisons and reads from `args[i + 1]`.
- Add `i++;` inside each matched branch after assignment/parsing.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._