### PR TITLE
Fix for Array index out of bounds

### DIFF
--- a/java_package/brainflow/src/main/java/brainflow/examples/BrainFlowGetData.java
+++ b/java_package/brainflow/src/main/java/brainflow/examples/BrainFlowGetData.java
@@ -38,6 +38,18 @@ public class BrainFlowGetData
         int board_id = -1;
         for (int i = 0; i < args.length; i++)
         {
+            if ((args[i].equals ("--ip-address") || args[i].equals ("--ip-address-aux")
+                    || args[i].equals ("--ip-address-anc") || args[i].equals ("--serial-port")
+                    || args[i].equals ("--ip-port") || args[i].equals ("--ip-port-aux")
+                    || args[i].equals ("--ip-port-anc") || args[i].equals ("--ip-protocol")
+                    || args[i].equals ("--other-info") || args[i].equals ("--board-id")
+                    || args[i].equals ("--timeout") || args[i].equals ("--serial-number")
+                    || args[i].equals ("--file") || args[i].equals ("--file-aux")
+                    || args[i].equals ("--file-anc") || args[i].equals ("--master-board"))
+                    && (i + 1 >= args.length))
+            {
+                throw new IllegalArgumentException ("Missing value for argument: " + args[i]);
+            }
             if (args[i].equals ("--ip-address"))
             {
                 params.ip_address = args[i + 1];


### PR DESCRIPTION
General fix: ensure every flag that consumes a value verifies one exists before reading `args[i + 1]`. A clean way is to guard all option-value handling with `i + 1 < args.length`, and fail fast with a clear exception if a value is missing.

Best single fix (without changing intended functionality): in `parse_args` in `java_package/brainflow/src/main/java/brainflow/examples/BrainFlowGetData.java`, add an early check inside the loop for all known value-taking flags. If such a flag is found at the last position, throw `IllegalArgumentException` with a helpful message. This preserves existing parsing behavior for valid input while preventing out-of-bounds access.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._