### PR TITLE
Fix for Array index out of bounds

### DIFF
--- a/java_package/brainflow/src/main/java/brainflow/examples/BrainFlowGetData.java
+++ b/java_package/brainflow/src/main/java/brainflow/examples/BrainFlowGetData.java
@@ -38,67 +38,78 @@ public class BrainFlowGetData
         int board_id = -1;
         for (int i = 0; i < args.length; i++)
         {
-            if (args[i].equals ("--ip-address"))
+            String arg = args[i];
+            if ((arg.equals ("--ip-address") || arg.equals ("--ip-address-aux") || arg.equals ("--ip-address-anc")
+                    || arg.equals ("--serial-port") || arg.equals ("--ip-port") || arg.equals ("--ip-port-aux")
+                    || arg.equals ("--ip-port-anc") || arg.equals ("--ip-protocol") || arg.equals ("--other-info")
+                    || arg.equals ("--board-id") || arg.equals ("--timeout") || arg.equals ("--serial-number")
+                    || arg.equals ("--file") || arg.equals ("--file-aux") || arg.equals ("--file-anc")
+                    || arg.equals ("--master-board")) && (i + 1 >= args.length))
+            {
+                throw new IllegalArgumentException ("Missing value for argument: " + arg);
+            }
+
+            if (arg.equals ("--ip-address"))
             {
                 params.ip_address = args[i + 1];
             }
-            if (args[i].equals ("--ip-address-aux"))
+            if (arg.equals ("--ip-address-aux"))
             {
                 params.ip_address_aux = args[i + 1];
             }
-            if (args[i].equals ("--ip-address-anc"))
+            if (arg.equals ("--ip-address-anc"))
             {
                 params.ip_address_anc = args[i + 1];
             }
-            if (args[i].equals ("--serial-port"))
+            if (arg.equals ("--serial-port"))
             {
                 params.serial_port = args[i + 1];
             }
-            if (args[i].equals ("--ip-port"))
+            if (arg.equals ("--ip-port"))
             {
                 params.ip_port = Integer.parseInt (args[i + 1]);
             }
-            if (args[i].equals ("--ip-port-aux"))
+            if (arg.equals ("--ip-port-aux"))
             {
                 params.ip_port_aux = Integer.parseInt (args[i + 1]);
             }
-            if (args[i].equals ("--ip-port-anc"))
+            if (arg.equals ("--ip-port-anc"))
             {
                 params.ip_port_anc = Integer.parseInt (args[i + 1]);
             }
-            if (args[i].equals ("--ip-protocol"))
+            if (arg.equals ("--ip-protocol"))
             {
                 params.ip_protocol = Integer.parseInt (args[i + 1]);
             }
-            if (args[i].equals ("--other-info"))
+            if (arg.equals ("--other-info"))
             {
                 params.other_info = args[i + 1];
             }
-            if (args[i].equals ("--board-id"))
+            if (arg.equals ("--board-id"))
             {
                 board_id = Integer.parseInt (args[i + 1]);
             }
-            if (args[i].equals ("--timeout"))
+            if (arg.equals ("--timeout"))
             {
                 params.timeout = Integer.parseInt (args[i + 1]);
             }
-            if (args[i].equals ("--serial-number"))
+            if (arg.equals ("--serial-number"))
             {
                 params.serial_number = args[i + 1];
             }
-            if (args[i].equals ("--file"))
+            if (arg.equals ("--file"))
             {
                 params.file = args[i + 1];
             }
-            if (args[i].equals ("--file-aux"))
+            if (arg.equals ("--file-aux"))
             {
                 params.file_aux = args[i + 1];
             }
-            if (args[i].equals ("--file-anc"))
+            if (arg.equals ("--file-anc"))
             {
                 params.file_anc = args[i + 1];
             }
-            if (args[i].equals ("--master-board"))
+            if (arg.equals ("--master-board"))
             {
                 params.master_board = Integer.parseInt (args[i + 1]);
             }


### PR DESCRIPTION
General fix: only read `args[i + 1]` when it exists. For options that require a value, guard with `i + 1 < args.length`; if missing, fail fast with a clear exception.

Best fix in this file: in `parse_args` (lines ~36–106), add a single guard at the top of the loop to validate value-bearing flags before any branch accesses `args[i + 1]`. This avoids repetitive checks and preserves existing behavior for valid inputs. Then keep the existing assignments/parsing logic unchanged.

Concretely:
- File: `java_package/brainflow/src/main/java/brainflow/examples/BrainFlowGetData.java`
- Region: inside `parse_args`, immediately inside the `for` loop and before first `if (args[i].equals(...))`.
- Add:
  - `String arg = args[i];`
  - a combined condition checking whether `arg` is one of the value-requiring flags and `i + 1 >= args.length`
  - throw `IllegalArgumentException` with a helpful message.
- Optionally use `arg` in existing `if` statements for readability (no functional change).

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._