### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/nodejs_package/tests/bandpower.ts
+++ b/nodejs_package/tests/bandpower.ts
@@ -14,7 +14,7 @@ async function runExample (): Promise<void>
     await sleep (5000);
     board.stopStream();
     const data = board.getCurrentBoardData(128);
-    board.releaseSession()
+    board.releaseSession();
     const eegChannels = BoardShim.getEegChannels(boardId);
     const samplingRate = BoardShim.getSamplingRate(boardId);
     const oldData = data[eegChannels[1]];


### PR DESCRIPTION
To fix this, make semicolon usage consistent in `runExample` by adding an explicit semicolon to the statement on line 17.

Best single fix without changing functionality:
- File: `nodejs_package/tests/bandpower.ts`
- Region: around lines 15–19
- Change:
  - `board.releaseSession()` → `board.releaseSession();`

No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._