### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/nodejs_package/tests/downsampling.ts
+++ b/nodejs_package/tests/downsampling.ts
@@ -14,7 +14,7 @@ async function runExample (): Promise<void>
     await sleep (3000);
     board.stopStream();
     const data = board.getCurrentBoardData(10);
-    board.releaseSession()
+    board.releaseSession();
     const eegChannels = BoardShim.getEegChannels(boardId);
     const oldData = data[eegChannels[0]];
     console.info(oldData);


### PR DESCRIPTION
To fix this, make semicolon usage consistent by adding the missing semicolon to line 17 in `nodejs_package/tests/downsampling.ts`.

Best single fix without changing behavior:
- In `runExample`, change `board.releaseSession()` to `board.releaseSession();`.
- No imports, helper methods, or additional definitions are needed.
- This is a minimal, non-functional formatting correction aligned with existing code style in the same function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._