### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/nodejs_package/tests/denoising.ts
+++ b/nodejs_package/tests/denoising.ts
@@ -14,7 +14,7 @@ async function runExample (): Promise<void>
     await sleep (5000);
     board.stopStream();
     const data = board.getBoardData();
-    board.releaseSession()
+    board.releaseSession();
     const eegChannels = BoardShim.getEegChannels(boardId);
     const oldData = data[eegChannels[0]];
     console.info(oldData);


### PR DESCRIPTION
Add the missing semicolon to the `board.releaseSession()` statement in `nodejs_package/tests/denoising.ts` inside `runExample`.

Best fix without changing functionality:
- Edit line 17 from `board.releaseSession()` to `board.releaseSession();`.
- No logic changes, no imports, no new methods, no dependency changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._