### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/nodejs_package/tests/eeg_metrics.ts
+++ b/nodejs_package/tests/eeg_metrics.ts
@@ -21,7 +21,7 @@ async function runExample (): Promise<void>
     await sleep (3000);
     board.stopStream();
     const data = board.getBoardData();
-    board.releaseSession()
+    board.releaseSession();
     console.info(data);
     const eegChannels = BoardShim.getEegChannels(boardId);
     const samplingRate = BoardShim.getSamplingRate(boardId);


### PR DESCRIPTION
To fix this, make semicolon usage consistent by adding an explicit semicolon at the end of `board.releaseSession()` in `nodejs_package/tests/eeg_metrics.ts`.

Best single fix (no functional change):
- In `runExample`, update line 24 from:
  - `board.releaseSession()`
  to:
  - `board.releaseSession();`

No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._