### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/nodejs_package/tests/transforms.ts
+++ b/nodejs_package/tests/transforms.ts
@@ -21,7 +21,7 @@ async function runExample (): Promise<void>
     await sleep (3000);
     board.stopStream();
     const data = board.getCurrentBoardData(64);
-    board.releaseSession()
+    board.releaseSession();
     const eegChannels = BoardShim.getEegChannels(boardId);
     const oldData = data[eegChannels[0]];
     console.info(oldData);


### PR DESCRIPTION
To fix this, make statement termination consistent by adding an explicit semicolon to line 24 in `nodejs_package/tests/transforms.ts`.

Best single fix without changing behavior:
- In `runExample()`, change:
  - `board.releaseSession()`
  - to `board.releaseSession();`

No imports, new methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._