### PR TITLE
Fix for Empty except

### DIFF
--- a/python_package/brainflow/board_shim.py
+++ b/python_package/brainflow/board_shim.py
@@ -191,7 +191,10 @@ class BoardControllerDLL(object):
             # for python 3.8 PATH env var doesnt work anymore
             try:
                 os.add_dll_directory(dir_path)
-            except:
+            except (AttributeError, FileNotFoundError, OSError):
+                # Best effort only: this may be unavailable or fail on some
+                # platforms/runtime configurations; PATH/LD_LIBRARY_PATH is
+                # updated below as a fallback.
                 pass
             if platform.system() == 'Windows':
                 os.environ['PATH'] = dir_path + os.pathsep + os.environ.get('PATH', '')


### PR DESCRIPTION
To fix this without changing functionality, keep the best-effort behavior but replace the bare `except:` with explicit exception handling for expected failures from `os.add_dll_directory` and add a concise comment explaining why ignoring those failures is acceptable.

Best change in `python_package/brainflow/board_shim.py` around lines 192–195:
- Replace:
  - `except:`
  - `pass`
- With:
  - `except (AttributeError, FileNotFoundError, OSError):`
  - a comment documenting that failing to add a DLL directory is non-fatal because fallback env var handling follows
  - `pass`

No new imports or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._