### PR TITLE
Fix for Empty except

### DIFF
--- a/python_package/brainflow/ml_model.py
+++ b/python_package/brainflow/ml_model.py
@@ -94,7 +94,9 @@ class MLModuleDLL(object):
             dir_path = os.path.abspath(os.path.dirname(full_path))
             try:
                 os.add_dll_directory(dir_path)
-            except:
+            except (AttributeError, OSError):
+                # Ignore when API is unavailable or directory registration fails;
+                # PATH/LD_LIBRARY_PATH fallback is applied below.
                 pass
             if platform.system() == 'Windows':
                 os.environ['PATH'] = dir_path + os.pathsep + os.environ.get('PATH', '')


### PR DESCRIPTION
General fix: replace bare `except:` + `pass` with targeted exception handling and an explanatory comment, so only expected failures are ignored.

Best fix here (without changing behavior): in `python_package/brainflow/ml_model.py`, inside `MLModuleDLL.__init__`, change:

- `except:` to `except (AttributeError, OSError):`
- keep `pass` but add a clear explanatory comment stating why it is safe to continue.

Why these exceptions:
- `AttributeError`: `os.add_dll_directory` may not exist on some Python/platform combinations.
- `OSError`: call can fail depending on runtime environment/permissions/path handling.

No imports or new methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._