### PR TITLE
Fix for Empty except

### DIFF
--- a/python_package/examples/spotify_dataset_collection/spotify_data_collection.py
+++ b/python_package/examples/spotify_dataset_collection/spotify_data_collection.py
@@ -50,8 +50,11 @@ class DataThread(threading.Thread):
                             counter_for_duration = counter_for_duration + 1
                             is_end = False
                             is_playing = True
-                        except BaseException:
-                            pass
+                        except (AttributeError, TypeError) as e:
+                            BoardShim.log_message(
+                                LogLevels.LEVEL_WARN.value,
+                                'Failed to read current track info, skipping this poll iteration: %s' % str(e)
+                            )
                     elif not track.get('is_playing', True):
                         is_end = True
                 except AttributeError as e:


### PR DESCRIPTION
To fix this safely without changing intended functionality, replace the `except BaseException: pass` with a narrow, documented/logged handler for expected transient data-shape issues.  
Best change here: catch `AttributeError` (and optionally `TypeError`) for the flaky track payload and log at warning level, then continue loop behavior as before.

In `python_package/examples/spotify_dataset_collection/spotify_data_collection.py`, edit the inner `try/except` around `current_song_id = track.get('item', {}).get('id')` so that:
- it no longer catches `BaseException`,
- it no longer silently passes,
- it logs a warning via `BoardShim.log_message(...)`.

No imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._