### PR TITLE
Fix for Empty except

### DIFF
--- a/python_package/brainflow/data_filter.py
+++ b/python_package/brainflow/data_filter.py
@@ -167,7 +167,8 @@ class DataHandlerDLL(object):
             # for python 3.8 PATH env var doesnt work anymore
             try:
                 os.add_dll_directory(dir_path)
-            except:
+            except (AttributeError, OSError):
+                # Best-effort: continue and rely on PATH fallback below.
                 pass
             if platform.system() == 'Windows':
                 os.environ['PATH'] = dir_path + os.pathsep + os.environ.get('PATH', '')


### PR DESCRIPTION
Use a **targeted exception handler** instead of `except:` and keep the operation explicitly best-effort.

Best fix (without changing functionality):
- In `python_package/brainflow/data_filter.py`, inside `DataHandlerDLL.__init__`, replace:
  - `except:` + `pass`
- With:
  - `except (AttributeError, OSError):` + explanatory comment + `pass`

Why this is best:
- `AttributeError` covers environments where `os.add_dll_directory` is unavailable.
- `OSError` covers expected runtime failures when adding the directory.
- Behavior remains the same (non-fatal, continue to PATH fallback), but avoids catching unrelated exceptions and satisfies CodeQL’s requirement for meaningful handling/commenting.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._