### PR TITLE
Fix for Empty except

### DIFF
--- a/emulator/brainflow_emulator/biolistener_emulator.py
+++ b/emulator/brainflow_emulator/biolistener_emulator.py
@@ -113,8 +113,10 @@ class BioListenerEmulator(threading.Thread):
                 # A failed connect may leave the socket unusable.
                 try:
                     self.server_socket.close()
-                except Exception:
-                    pass
+                except Exception as close_err:
+                    # Closing can fail if the socket is already invalid/closed after connect failure.
+                    # Ignore and continue with socket recreation.
+                    logging.debug(f"Ignoring socket close error during reconnect cleanup: {close_err}")
                 # Recreate the socket with the same options.
                 self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
To fix this without changing behavior, keep the exception suppression during socket cleanup but add an explanatory comment and lightweight logging in the `except` block. This satisfies the rule’s requirement and preserves reconnect flow.

Best change in `emulator/brainflow_emulator/biolistener_emulator.py` (around lines 114–118 in `run`):
- Replace the `except Exception: pass` with:
  - `except Exception as close_err:`
  - a short comment explaining close failures are expected/ignorable in reconnect cleanup
  - `logging.debug(...)` including the exception for diagnostics.

No new imports or dependencies are required (the file already imports `logging`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._