### PR TITLE
Fix for Empty except

### DIFF
--- a/emulator/brainflow_emulator/biolistener_emulator.py
+++ b/emulator/brainflow_emulator/biolistener_emulator.py
@@ -164,8 +164,10 @@ class BioListenerEmulator(threading.Thread):
                         else:
                             logging.warning(f"Unknown command: {json_str['command']}")
             except TimeoutError:
+                # Expected when no command arrives before socket timeout; continue polling.
                 pass
             except socket.timeout:
+                # Expected polling timeout; ignore and keep loop alive.
                 pass
             except Exception as err:
                 logging.error(f"Error in recv thread: {err}")


### PR DESCRIPTION
To fix this without changing behavior, keep the timeout handlers but add explicit explanatory comments in those `except` blocks to document that timeout is expected during polling and the loop should continue.

Best single fix:
- In `emulator/brainflow_emulator/biolistener_emulator.py`, update the two empty `except` clauses in the receive loop:
  - `except TimeoutError:`
  - `except socket.timeout:`
- Replace `pass` with `pass` plus a short comment (or just a comment plus `pass`) explaining that timeout is normal when no command is received and should not be logged as an error.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._