### PR TITLE
Fix for Empty except

### DIFF
--- a/emulator/brainflow_emulator/biolistener_emulator.py
+++ b/emulator/brainflow_emulator/biolistener_emulator.py
@@ -166,6 +166,7 @@ class BioListenerEmulator(threading.Thread):
             except TimeoutError:
                 pass
             except socket.timeout:
+                # Expected when no command is received before socket timeout; continue loop.
                 pass
             except Exception as err:
                 logging.error(f"Error in recv thread: {err}")


### PR DESCRIPTION
To fix this without changing functionality, keep ignoring `socket.timeout` but add an explanatory comment in that `except` block clarifying that timeout is expected in the receive loop and should not interrupt streaming/sending logic.

Best single change:
- File: `emulator/brainflow_emulator/biolistener_emulator.py`
- Region: `run()` method, `try/except` around `recv`, specifically the `except socket.timeout:` block (around lines 168–169).
- Replace the empty `pass` with a commented no-op:
  - Add a short comment (e.g., “Expected when no command arrives within socket timeout; continue loop.”)
  - Keep `pass` to preserve behavior.

No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._