### PR TITLE
Fix for Unused import

### DIFF
--- a/emulator/brainflow_emulator/biolistener_emulator.py
+++ b/emulator/brainflow_emulator/biolistener_emulator.py
@@ -1,4 +1,3 @@
-import datetime
 import enum
 import json
 import logging


### PR DESCRIPTION
To fix this, remove the unused `datetime` import from `emulator/brainflow_emulator/biolistener_emulator.py`.

Best single change without affecting functionality:
- In the import block at the top of the file, delete `import datetime`.
- Keep all other imports unchanged.

No new methods, definitions, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._