### PR TITLE
Fix for Unused global variable

### DIFF
--- a/python_package/examples/tests/eego_impedances_and_eeg.py
+++ b/python_package/examples/tests/eego_impedances_and_eeg.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     # Get impedance data
     board.config_board('impedance_mode:1')
     board.start_stream()
-    for i in range(5):
+    for _ in range(5):
         time.sleep(1)
         data = board.get_board_data()  # get all data and remove it from internal buffer
         print(f'{data.shape[0]} channels x {data.shape[1]} samples')
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     # Get EEG data
     board.config_board('impedance_mode:0')
     board.start_stream()
-    for i in range(3):
+    for _ in range(3):
         time.sleep(1)
         data = board.get_board_data()  # get all data and remove it from internal buffer
         print(f'{data.shape[0]} channels x {data.shape[1]} samples')


### PR DESCRIPTION
To fix this, replace unused loop variable names with `_` in loops where the counter is not used.

Best minimal fix in `python_package/examples/tests/eego_impedances_and_eeg.py`:
- Change line 20 from `for i in range(5):` to `for _ in range(5):`
- Change line 29 from `for i in range(3):` to `for _ in range(3):`

No behavior changes, no new imports, no additional methods/definitions needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._