### PR TITLE
Fix for Unused global variable

### DIFF
--- a/python_package/examples/tests/eego_impedances_and_eeg.py
+++ b/python_package/examples/tests/eego_impedances_and_eeg.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     # Get impedance data
     board.config_board('impedance_mode:1')
     board.start_stream()
-    for i in range(5):
+    for _ in range(5):
         time.sleep(1)
         data = board.get_board_data()  # get all data and remove it from internal buffer
         print(f'{data.shape[0]} channels x {data.shape[1]} samples')
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     # Get EEG data
     board.config_board('impedance_mode:0')
     board.start_stream()
-    for i in range(3):
+    for _ in range(3):
         time.sleep(1)
         data = board.get_board_data()  # get all data and remove it from internal buffer
         print(f'{data.shape[0]} channels x {data.shape[1]} samples')


### PR DESCRIPTION
Use `_` as the loop variable for loops where the counter is intentionally unused. In Python, `_` is the conventional placeholder name for values that are not needed. This keeps behavior identical and removes the unused-variable warning.

In `python_package/examples/tests/eego_impedances_and_eeg.py`, replace both `for i in range(...)` loops with `for _ in range(...)`. No imports, helper methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._