### PR TITLE
Fix for Useless toString on String

### DIFF
--- a/java_package/brainflow/src/main/java/brainflow/JarHelper.java
+++ b/java_package/brainflow/src/main/java/brainflow/JarHelper.java
@@ -24,7 +24,7 @@ public class JarHelper
         }
         try
         {
-            System.err.println ("Unpacking to: " + file.getAbsolutePath ().toString ());
+            System.err.println ("Unpacking to: " + file.getAbsolutePath ());
             if (file.exists ())
                 file.delete ();
             InputStream link = (JarHelper.class.getResourceAsStream (lib_name));


### PR DESCRIPTION
To fix this, remove the unnecessary `.toString()` call from the logging statement in `unpack_from_jar`.  
Best minimal fix (no functional change): replace:

- `file.getAbsolutePath ().toString ()`

with:

- `file.getAbsolutePath ()`

in `java_package/brainflow/src/main/java/brainflow/JarHelper.java` at the `System.err.println` line inside the second `try` block (around line 27). No imports, helper methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._