### PR TITLE
Fix wavelet coefficient buffer under allocation in five bindings

### DIFF
--- a/.github/workflows/run_unix.yml
+++ b/.github/workflows/run_unix.yml
@@ -354,6 +354,8 @@ jobs:
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/transforms.py
     - name: Downsampling Python
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/downsampling.py
+    - name: Wavelet Buffer Size Python
+      run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/wavelet_buffer_size.py
     - name: ICA Python
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/ica.py
     - name: CSP Python

--- a/.github/workflows/run_windows.yml
+++ b/.github/workflows/run_windows.yml
@@ -235,6 +235,9 @@ jobs:
     - name: Downsampling Python Test
       run: python %GITHUB_WORKSPACE%\python_package\examples\tests\downsampling.py
       shell: cmd
+    - name: Wavelet Buffer Size Python Test
+      run: python %GITHUB_WORKSPACE%\python_package\examples\tests\wavelet_buffer_size.py
+      shell: cmd
     - name: CSP Python Test
       run: python %GITHUB_WORKSPACE%\python_package\examples\tests\csp.py
       shell: cmd

--- a/csharp_package/brainflow/brainflow/data_filter.cs
+++ b/csharp_package/brainflow/brainflow/data_filter.cs
@@ -351,7 +351,7 @@ namespace brainflow
         /// <returns>tuple of wavelet coeffs in format [A(J) D(J) D(J-1) ..... D(1)] where J is decomposition level, A - app coeffs, D - detailed coeffs, and array with lengths for each block</returns>
         public static Tuple<double[], int[]> perform_wavelet_transform (double[] data, int wavelet, int decomposition_level, int extension)
         {
-            double[] wavelet_coeffs = new double[data.Length + 2 * (40 + 1)];
+            double[] wavelet_coeffs = new double[data.Length + 2 * decomposition_level * (40 + 1)];
             int[] lengths = new int[decomposition_level + 1];
             int res = DataHandlerLibrary.perform_wavelet_transform (data, data.Length, wavelet, decomposition_level, extension, wavelet_coeffs, lengths);
             if (res != (int)BrainFlowExitCodes.STATUS_OK)
@@ -1115,7 +1115,7 @@ namespace brainflow
         /// <returns>tuple of wavelet coeffs in format [A(J) D(J) D(J-1) ..... D(1)] where J is decomposition level, A - app coeffs, D - detailed coeffs, and array with lengths for each block</returns>
         public static unsafe Tuple<double[], int[]> perform_wavelet_transform (double[,] data, int row_num, int wavelet, int decomposition_level, int extension)
         {
-            double[] wavelet_coeffs = new double[data.Length + 2 * (40 + 1)];
+            double[] wavelet_coeffs = new double[data.GetLength (1) + 2 * decomposition_level * (40 + 1)];
             int[] lengths = new int[decomposition_level + 1];
             int res = (int)BrainFlowExitCodes.STATUS_OK;
             if ((row_num < 0) || (row_num >= data.GetLength (0)))

--- a/julia_package/brainflow/src/data_filter.jl
+++ b/julia_package/brainflow/src/data_filter.jl
@@ -297,7 +297,7 @@ end
 end
 
 @brainflow_rethrow function perform_wavelet_transform(data, wavelet::WaveletType, decomposition_level::Integer, extension::WaveletExtensionType)
-    wavelet_coeffs = Vector{Float64}(undef, length(data) + 2 * (40 + 1))
+    wavelet_coeffs = Vector{Float64}(undef, length(data) + 2 * decomposition_level * (40 + 1))
     lengths = Vector{Cint}(undef, decomposition_level + 1)
     ccall((:perform_wavelet_transform, DATA_HANDLER_INTERFACE), Cint, (Ptr{Float64}, Cint, Cint, Cint, Cint, Ptr{Float64}, Ptr{Cint}),
             data, length(data), Int32(wavelet), Int32(decomposition_level), Int32(extension), wavelet_coeffs, lengths)

--- a/matlab_package/brainflow/DataFilter.m
+++ b/matlab_package/brainflow/DataFilter.m
@@ -186,7 +186,7 @@ classdef DataFilter
             task_name = 'perform_wavelet_transform';
             temp_input = libpointer('doublePtr', data);
             lib_name = DataFilter.load_lib();
-            temp_output = libpointer('doublePtr', zeros(1, int32(size(data, 2) + 2 *(40 + 1))));
+            temp_output = libpointer('doublePtr', zeros(1, int32(size(data, 2) + 2 * decomposition_level * (40 + 1))));
             lenghts = libpointer('int32Ptr', zeros(1, decomposition_level + 1));
             exit_code = calllib(lib_name, task_name, temp_input, size(data, 2), wavelet, decomposition_level, extension, temp_output, lenghts);
             DataFilter.check_ec(exit_code, task_name);

--- a/nodejs_package/brainflow/data_filter.ts
+++ b/nodejs_package/brainflow/data_filter.ts
@@ -491,7 +491,7 @@ export class DataFilter
     public static performWaveletTransform(data: number[], wavelet: WaveletTypes,
         decompositionLevel: number, extension: WaveletExtensionTypes): [number[], number[]]
     {
-        const waveletCoeffs = [...new Array (data.length + 2 * (40 + 1)).fill(0)];
+        const waveletCoeffs = [...new Array (data.length + 2 * decompositionLevel * (40 + 1)).fill(0)];
         const lengths = [...new Array (decompositionLevel + 1).fill(0)];
         const res = DataHandlerDLL.getInstance().performWaveletTransform(
             data, data.length, wavelet, decompositionLevel, extension, waveletCoeffs, lengths);

--- a/python_package/brainflow/data_filter.py
+++ b/python_package/brainflow/data_filter.py
@@ -878,7 +878,7 @@ class DataFilter(object):
         """
         check_memory_layout_row_major(data, 1)
 
-        wavelet_coeffs = numpy.zeros(data.shape[0] + 2 * (40 + 1)).astype(numpy.float64)
+        wavelet_coeffs = numpy.zeros(data.shape[0] + 2 * decomposition_level * (40 + 1)).astype(numpy.float64)
         lengths = numpy.zeros(decomposition_level + 1).astype(numpy.int32)
         res = DataHandlerDLL.get_instance().perform_wavelet_transform(data, data.shape[0], wavelet,
                                                                       decomposition_level, extension_type,

--- a/python_package/examples/tests/wavelet_buffer_size.py
+++ b/python_package/examples/tests/wavelet_buffer_size.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from brainflow.data_filter import DataFilter, WaveletExtensionTypes, WaveletTypes
+
+# db15 has a 30 tap filter, so a level 5 decomposition needs a reasonably long signal and
+# grows the coefficient array well past the old fixed 2 * (40 + 1) headroom.
+DATA_LEN = 1024
+DECOMPOSITION_LEVEL = 5
+
+
+def main():
+    rng = np.random.default_rng(3)
+    data = rng.standard_normal(DATA_LEN)
+
+    output = DataFilter.perform_wavelet_transform(
+        np.copy(data), WaveletTypes.DB15, DECOMPOSITION_LEVEL, WaveletExtensionTypes.SYMMETRIC
+    )
+    coeffs, lengths = output
+
+    # The binding allocated data_len + 2 * (40 + 1) regardless of decomposition level, but
+    # the native side writes sum(lengths) doubles. At db15 level 5 that is 1167 against an
+    # allocation of 1106, so the transform wrote past the end of the array. Comparing the
+    # returned coefficient count against sum(lengths) is what makes the shortfall visible,
+    # because the wrapper slices the buffer it allocated.
+    assert coeffs.shape[0] == int(np.sum(lengths)), (coeffs.shape[0], int(np.sum(lengths)))
+
+    # The headroom has to scale with the level, so an under-allocation at any level shows up.
+    for level in range(1, DECOMPOSITION_LEVEL + 1):
+        level_output = DataFilter.perform_wavelet_transform(
+            np.copy(data), WaveletTypes.DB15, level, WaveletExtensionTypes.SYMMETRIC
+        )
+        level_coeffs, level_lengths = level_output
+        assert level_coeffs.shape[0] == int(np.sum(level_lengths)), (
+            level,
+            level_coeffs.shape[0],
+            int(np.sum(level_lengths)),
+        )
+
+    # A truncated coefficient array cannot reconstruct the signal, so the round trip is the
+    # end-to-end check that nothing was lost.
+    restored = DataFilter.perform_inverse_wavelet_transform(
+        output, DATA_LEN, WaveletTypes.DB15, DECOMPOSITION_LEVEL, WaveletExtensionTypes.SYMMETRIC
+    )
+    assert restored.shape[0] == DATA_LEN, restored.shape
+    assert np.allclose(restored, data, atol=1e-8), np.max(np.abs(restored - data))
+
+    print('wavelet buffer size regression passed')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
`perform_wavelet_transform` writes `wt->outlength` doubles into the output buffer the caller supplies. The safe upper bound, taken from the wavelib sources, is `data_len + 2 * decomposition_level * (40 + 1)`. That is exactly what `cpp_package/src/data_filter.cpp`, `DataFilter.java`, `data_filter.rs`, the Swift `DataFilter.swift` and the internal caller at `src/data_handler/data_handler.cpp:1557` all allocate.

Five bindings dropped the `decomposition_level` factor and allocate only `data_len + 2 * (40 + 1)`: python `data_filter.py:881`, C# `data_filter.cs:354` and `:1118`, node `data_filter.ts:494`, matlab `DataFilter.m:189` and julia `data_filter.jl:300`. The R package calls through the python one, so it inherits the same buffer. Short wavelets stay under the smaller bound and hide the problem, but the longer filters do not, and the transform writes past the end of the buffer.

I measured the real write count by handing the C function a hugely oversized sentinel filled buffer and finding the highest index it touched, across 53 combinations of wavelet, length and level. The `decomposition_level` bound was never exceeded, 0 of 53. The smaller bound was exceeded in 6 of 53. The worst case is db15 with a 1024 sample input at level 5, which writes 1167 doubles into a 1106 slot buffer, 61 doubles or 488 bytes past the end. db15 already overflows at level 3, so this is a function of the wavelet filter length as well as the level, not level alone.

To confirm it is a genuine out of bounds write rather than an accounting mismatch, I mapped the buffer so its final byte is the final byte of a mapped page with a `PROT_NONE` guard page immediately after, then called `perform_wavelet_transform` through the built `libDataHandler`. At the old size of 1106 slots the process takes a hard fault, SIGBUS, exit status 138. At 1434 slots, which is what the corrected python formula gives for that case, it completes normally and reports 1167 coefficients.

There is a second, quieter symptom. Each wrapper slices the buffer to `sum(lengths)`, and when that total exceeds the buffer the slice silently clamps, so the caller gets a short coefficient vector. Through the public python API on 8 cases, 6 came back truncated before the change, for example db15 at level 5 returning 1106 of 1167 coefficients. The inverse transform then read past the end of that short array. After the change all 8 return the full vector and round trip to a maximum absolute error of 1.8e-15.

The fix restores the `decomposition_level` factor in all five bindings. The C# overload taking a 2d array also sized itself from `data.Length`, the total element count of the matrix, while passing `data.GetLength (1)` as the actual `data_len`, so I switched it to `GetLength (1)` to match what the C side is told and is now correct for a single row matrix too.

Verified on macOS arm64 against a fresh `cmake .. && make -j8` build. The nine synthetic board examples CI runs all pass: `denoising.py`, `signal_filtering.py`, `transforms.py`, `downsampling.py`, `band_power.py`, `band_power_all.py`, `windowing.py`, `ica.py` and `csp.py`. `transforms.py` is the one that exercises the wavelet path. The C# package builds with `dotnet build -c Release`, 0 warnings and 0 errors, and the node package typechecks with `tsc --noEmit`, exit 0. I have no julia or matlab toolchain locally, so those two are one line changes reviewed against the working java and rust versions rather than executed. There is no assertion based test surface for these functions, the existing coverage is demo scripts that plot rather than assert, so I could not extend one, but I am glad to add a db15 round trip case if you would like it covered in CI.
