### PR TITLE
Fix get_psd_welch Nyquist bin averaging and infinite loop when overlap equals nfft

### DIFF
--- a/.github/workflows/run_unix.yml
+++ b/.github/workflows/run_unix.yml
@@ -354,6 +354,8 @@ jobs:
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/transforms.py
     - name: Downsampling Python
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/downsampling.py
+    - name: PSD Welch Nyquist Overlap Python
+      run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/psd_welch_nyquist_overlap.py
     - name: ICA Python
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/ica.py
     - name: CSP Python

--- a/.github/workflows/run_windows.yml
+++ b/.github/workflows/run_windows.yml
@@ -235,6 +235,9 @@ jobs:
     - name: Downsampling Python Test
       run: python %GITHUB_WORKSPACE%\python_package\examples\tests\downsampling.py
       shell: cmd
+    - name: PSD Welch Nyquist Overlap Python Test
+      run: python %GITHUB_WORKSPACE%\python_package\examples\tests\psd_welch_nyquist_overlap.py
+      shell: cmd
     - name: CSP Python Test
       run: python %GITHUB_WORKSPACE%\python_package\examples\tests\csp.py
       shell: cmd

--- a/csharp_package/brainflow/brainflow/data_filter.cs
+++ b/csharp_package/brainflow/brainflow/data_filter.cs
@@ -751,7 +751,7 @@ namespace brainflow
         /// </summary>
         /// <param name="data">data for log PSD</param>
         /// <param name="nfft">FFT Size</param>
-        /// <param name="overlap">FFT Window overlap, must be between 0 and nfft</param>
+        /// <param name="overlap">FFT Window overlap, must be &gt;= 0 and &lt; nfft</param>
         /// <param name="sampling_rate">sampling rate</param>
         /// <param name="window">window function</param>
         /// <returns>Tuple of ampls and freqs arrays</returns>
@@ -1265,7 +1265,7 @@ namespace brainflow
         /// <param name="data">data for log PSD</param>
         /// <param name="row_num"></param>
         /// <param name="nfft">FFT Size</param>
-        /// <param name="overlap">FFT Window overlap, must be between 0 and nfft</param>
+        /// <param name="overlap">FFT Window overlap, must be &gt;= 0 and &lt; nfft</param>
         /// <param name="sampling_rate">sampling rate</param>
         /// <param name="window">window function</param>
         /// <returns>Tuple of ampls and freqs arrays</returns>

--- a/java_package/brainflow/src/main/java/brainflow/DataFilter.java
+++ b/java_package/brainflow/src/main/java/brainflow/DataFilter.java
@@ -960,7 +960,7 @@ public class DataFilter
      * 
      * @param data          data to process
      * @param nfft          size of FFT, must be even
-     * @param overlap       overlap between FFT Windows, must be between 0 and nfft
+     * @param overlap       overlap between FFT Windows, must be at least 0 and less than nfft
      * @param sampling_rate sampling rate
      * @param window        window function
      * @return pair of ampl and freq arrays
@@ -988,7 +988,7 @@ public class DataFilter
      * 
      * @param data          data to process
      * @param nfft          size of FFT, must be even
-     * @param overlap       overlap between FFT Windows, must be between 0 and nfft
+     * @param overlap       overlap between FFT Windows, must be at least 0 and less than nfft
      * @param sampling_rate sampling rate
      * @param window        window function
      * @return pair of ampl and freq arrays

--- a/python_package/brainflow/data_filter.py
+++ b/python_package/brainflow/data_filter.py
@@ -1105,7 +1105,7 @@ class DataFilter(object):
         :type data: NDArray[Shape["*"], Float64]
         :param nfft: FFT Window size, must be even
         :type nfft: int
-        :param overlap: overlap of FFT Windows, must be between 0 and nfft
+        :param overlap: overlap of FFT Windows, must be >= 0 and < nfft
         :type overlap: int
         :param sampling_rate: sampling rate
         :type sampling_rate: int

--- a/python_package/examples/tests/psd_welch_nyquist_overlap.py
+++ b/python_package/examples/tests/psd_welch_nyquist_overlap.py
@@ -1,0 +1,71 @@
+import threading
+
+import numpy as np
+
+from brainflow.data_filter import DataFilter, WindowOperations
+from brainflow.exit_codes import BrainFlowError, BrainFlowExitCodes
+
+HANG_TIMEOUT_SECONDS = 60
+
+
+def call_with_timeout(fn):
+    """Run fn on a worker thread so a non-terminating call fails instead of hanging.
+
+    ctypes releases the GIL around the native call, so the join below still returns while
+    the worker spins. Without this, a regression of the overlap guard would stall the whole
+    CI job rather than reporting a failure.
+    """
+    outcome = {}
+
+    def run():
+        try:
+            fn()
+            outcome['returned'] = True
+        except BrainFlowError as err:
+            outcome['exit_code'] = err.exit_code
+
+    worker = threading.Thread(target=run, daemon=True)
+    worker.start()
+    worker.join(HANG_TIMEOUT_SECONDS)
+    return worker.is_alive(), outcome
+
+
+def main():
+    nfft = 32
+    sampling_rate = 128
+    segments = 4
+    window = WindowOperations.HANNING.value
+
+    rng = np.random.default_rng(7)
+    data = rng.standard_normal(nfft * segments)
+
+    # overlap == nfft used to leave the segment cursor stationary, so the averaging loop
+    # never advanced and the call spun forever. The valid range is 0 <= overlap < nfft.
+    still_running, outcome = call_with_timeout(
+        lambda: DataFilter.get_psd_welch(np.copy(data), nfft, nfft, sampling_rate, window)
+    )
+    assert not still_running, 'get_psd_welch did not terminate with overlap equal to nfft'
+    assert outcome.get('exit_code') == BrainFlowExitCodes.INVALID_ARGUMENTS_ERROR.value, outcome
+
+    # With no overlap the segments are disjoint, so each Welch bin is exactly the mean of
+    # the per-segment PSD bins and can be checked against get_psd directly.
+    ampl, _ = DataFilter.get_psd_welch(np.copy(data), nfft, 0, sampling_rate, window)
+    per_segment = np.array(
+        [
+            DataFilter.get_psd(np.copy(data[i * nfft:(i + 1) * nfft]), sampling_rate, window)[0]
+            for i in range(segments)
+        ]
+    )
+    expected = np.mean(per_segment, axis=0)
+
+    assert ampl.shape[0] == nfft // 2 + 1, ampl.shape
+    # The averaging loop stopped at nfft / 2, so the final Nyquist bin kept the running sum
+    # over all segments instead of the average and read `segments` times too large.
+    assert np.allclose(ampl[-1], expected[-1]), (ampl[-1], expected[-1])
+    assert np.allclose(ampl, expected), (ampl, expected)
+
+    print('psd welch nyquist and overlap regression passed')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/data_handler/data_handler.cpp
+++ b/src/data_handler/data_handler.cpp
@@ -1239,7 +1239,7 @@ int get_psd_welch (double *data, int data_len, int nfft, int overlap, int sampli
     int window_function, double *output_ampl, double *output_freq)
 {
     if ((data == NULL) || (data_len < 1) || (nfft & (nfft - 1)) || (output_ampl == NULL) ||
-        (output_freq == NULL) || (sampling_rate < 1) || (overlap < 0) || (overlap > nfft))
+        (output_freq == NULL) || (sampling_rate < 1) || (overlap < 0) || (overlap >= nfft))
     {
         data_logger->error ("Please review your arguments.");
         return (int)BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR;
@@ -1270,7 +1270,7 @@ int get_psd_welch (double *data, int data_len, int nfft, int overlap, int sampli
         return (int)BrainFlowExitCodes::INVALID_ARGUMENTS_ERROR;
     }
     // average data
-    for (int i = 0; i < nfft / 2; i++)
+    for (int i = 0; i < nfft / 2 + 1; i++)
     {
         output_ampl[i] /= counter;
     }


### PR DESCRIPTION
`get_psd_welch` has two independent defects. Both are in the same function, so they are here together.

**The Nyquist bin is never averaged.** The accumulation loop sums `nfft / 2 + 1` bins across every segment, but the averaging loop divides only `nfft / 2` of them. The Nyquist bin at index `nfft / 2` is summed and never divided by the segment count, so it comes back inflated by exactly the number of segments. For a stationary signal that means the value grows without bound as you feed in more data, which is the opposite of what a Welch average is for. `get_band_power` integrates up to `data_len - 1`, so any band whose upper edge reaches the Nyquist frequency inherits the error.

**`overlap == nfft` hangs the process.** Argument validation accepts it, and the segment loop then advances by `pos += (nfft - overlap)`, which is zero. `pos` never moves, the loop condition never goes false, and the call spins forever inside the library with no way for the caller to recover.

The fix averages `nfft / 2 + 1` bins instead of `nfft / 2`, and rejects `overlap >= nfft` instead of `overlap > nfft`. Two characters each. The Python, C# and Java docstrings said the valid range was 0 to nfft inclusive, so they are corrected too.

Verified by building `libDataHandler.dylib` on macOS arm64 and calling the C API directly, comparing against a reference Welch average computed by calling `get_psd` on each segment and averaging every bin including Nyquist.

Nyquist bin, `nfft=64`, `overlap=0`, `sampling_rate=256`, signal containing a tone exactly at the 128 Hz Nyquist frequency:

| data_len | segments | before | after | reference |
|---|---|---|---|---|
| 64  | 1 | 0.25000118 | 0.25000118 | 0.25000118 |
| 128 | 2 | 0.50000000 | 0.25000000 | 0.25000000 |
| 256 | 4 | 1.00000000 | 0.25000000 | 0.25000000 |
| 384 | 6 | 1.50000000 | 0.25000000 | 0.25000000 |
| 512 | 8 | 2.00000000 | 0.25000000 | 0.25000000 |

The before to reference ratio is 1.0000, 2.0000, 3.0000 up to 8.0000, exactly the segment count. Every other bin already matched the reference to 0.000e+00 absolute difference before the fix, which isolates the defect to the single Nyquist bin.

Propagation into `get_band_power`, 6 segments:

| band | before | after | reference |
|---|---|---|---|
| 4 to 8 Hz (theta) | 0.13650396 | 0.13650396 | 0.13650396 |
| 8 to 13 Hz (alpha) | 0.13690234 | 0.13690234 | 0.13690234 |
| 30 to 50 Hz (gamma) | 0.00000038 | 0.00000038 | 0.00000038 |
| 100 to 128 Hz (reaches Nyquist) | 3.52343750 | 1.02343750 | 1.02343750 |

Bands that stop short of Nyquist are untouched. The band that reaches it was 3.44x too large.

For the hang, `get_psd_welch(data_len=256, nfft=64, overlap=64, ...)` under `timeout 15` was killed at 15016 ms with exit 124 before, and returns 13 (`INVALID_ARGUMENTS_ERROR`) in 9 ms after. Overlaps 0, 8, 16, 32 and 63 all still return `STATUS_OK` with unchanged values.

All 9 signal processing examples that CI runs pass on this branch. `clang-format` reports no changes on the touched files, and `dotnet build` is clean at 0 warnings and 0 errors. The Java change is javadoc only and was not compiled since there is no `mvn` here, but I checked it with `javac -Xdoclint:html` after rewording a bare `<` that would otherwise trip doclint.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
