### PR TITLE
Fix perform_fft ignoring get_window failure and transforming uninitialized memory

### DIFF
--- a/.github/workflows/run_unix.yml
+++ b/.github/workflows/run_unix.yml
@@ -354,6 +354,8 @@ jobs:
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/transforms.py
     - name: Downsampling Python
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/downsampling.py
+    - name: FFT Window Error Python
+      run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/fft_window_error.py
     - name: ICA Python
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/ica.py
     - name: CSP Python

--- a/python_package/examples/tests/fft_window_error.py
+++ b/python_package/examples/tests/fft_window_error.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+from brainflow.data_filter import DataFilter, DataHandlerDLL, WindowOperations
+from brainflow.exit_codes import BrainFlowError, BrainFlowExitCodes
+
+
+def main():
+    data_len = 64
+    data = np.arange(data_len, dtype=np.float64)
+
+    # Call the native entry point directly rather than DataFilter.perform_fft, because the
+    # wrapper allocates the output buffers itself and raises before returning them. Filling
+    # them with sentinels here is what makes "left untouched" observable.
+    original = np.copy(data)
+    real = np.full(data_len // 2 + 1, -12345.0)
+    imag = np.full(data_len // 2 + 1, -54321.0)
+
+    invalid_window = 999
+    res = DataHandlerDLL.get_instance().perform_fft(data, data_len, invalid_window, real, imag)
+
+    assert res == BrainFlowExitCodes.INVALID_ARGUMENTS_ERROR.value, res
+    # perform_fft used to ignore the get_window failure and transform the uninitialized
+    # window buffer, so both outputs were written with values derived from garbage.
+    assert np.all(real == -12345.0), real
+    assert np.all(imag == -54321.0), imag
+    assert np.array_equal(data, original), data
+
+    # The same failure through the public wrapper, which turns the code into an exception.
+    try:
+        DataFilter.perform_fft(np.arange(data_len, dtype=np.float64), invalid_window)
+    except BrainFlowError as err:
+        assert err.exit_code == BrainFlowExitCodes.INVALID_ARGUMENTS_ERROR.value, err.exit_code
+    else:
+        raise AssertionError('an invalid window function must not be accepted')
+
+    # A valid window still round-trips, so the early return did not shadow the normal path.
+    restored = DataFilter.perform_ifft(
+        DataFilter.perform_fft(np.copy(original), WindowOperations.NO_WINDOW.value)
+    )
+    assert np.allclose(restored, original), restored
+
+    print('fft window error regression passed')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/data_handler/data_handler.cpp
+++ b/src/data_handler/data_handler.cpp
@@ -788,7 +788,12 @@ int perform_fft (
     }
 
     double *windowed_data = new double[data_len];
-    get_window (window_function, data_len, windowed_data);
+    int window_res = get_window (window_function, data_len, windowed_data);
+    if (window_res != (int)BrainFlowExitCodes::STATUS_OK)
+    {
+        delete[] windowed_data;
+        return window_res;
+    }
     for (int i = 0; i < data_len; i++)
     {
         windowed_data[i] *= data[i];


### PR DESCRIPTION
`perform_fft` allocates `windowed_data` with `new double[data_len]` and calls `get_window` to fill it, then discards the return code. When `window_function` is not a valid `WindowOperations` value, `get_window` returns `INVALID_ARGUMENTS_ERROR` without writing a single element. The very next loop does `windowed_data[i] *= data[i]` on that never initialized buffer, `kiss_fftr` transforms the result, and `perform_fft` returns `STATUS_OK`. The caller receives a spectrum computed from whatever bytes the allocator happened to hand back, with no indication anything went wrong.

The fix checks the code from `get_window`, frees `windowed_data` and returns the error. `get_psd` already checks the `perform_fft` return value, so the error now propagates the whole way up through `get_psd_welch` to `get_band_power` and `get_custom_band_powers`, and the language bindings raise instead of returning a garbage spectrum.

Verified by building `libDataHandler.dylib` on macOS arm64 and calling `perform_fft` with `window_function = 99`. To make the uninitialized read observable rather than merely arguable, the harness supplies a global replacement `operator new[]` that pre-fills every heap block with a chosen value. That is a standard C++ replacement function, so it covers the `new double[data_len]` inside the library. Input is a pure 5 cycle sine over 64 samples, so all energy lands in bin 5.

| | before | after |
|---|---|---|
| `get_window(99)` called directly | 13 | 13 |
| `perform_fft(99)` return code | 0 (STATUS_OK) | 13 (INVALID_ARGUMENTS_ERROR) |
| output bins overwritten by the failed call | 33 of 33 | 0 of 33 |
| bins differing between two runs with different heap contents | 33 of 33 | 0 of 33 |
| magnitude at bin 5, heap filled with 7.0 | 224.000000 | untouched |
| magnitude at bin 5, heap filled with -3.0 | 96.000000 | untouched |
| ratio of magnitude to heap fill value | 32.0 in both cases | n/a |

The reported spectrum was exactly `|heap contents| * FFT(data)`. Change the heap, the spectrum changes proportionally, and the function still reported success. After the fix the output buffers still hold the caller's `-12345.0` sentinel, so nothing is written on the error path.

All four valid window functions are unaffected. `NO_WINDOW`, `HANNING`, `HAMMING` and `BLACKMAN_HARRIS` all return 0 and round trip through `perform_ifft` back to `window[i] * data[i]` with maximum error between 2.371e-16 and 3.908e-16, identical before and after.

All 9 signal processing examples that CI runs pass on this branch, and `clang-format` reports no changes on the touched file.

One note for anyone reproducing this: valgrind and MemorySanitizer are both unavailable on macOS arm64, and an attempt using `MallocScribble` plus heap priming produces all zeros and proves nothing. The `operator new[]` replacement is what makes the read observable.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
