### PR TITLE
Fix downsample_median returning the mean for even periods

### DIFF
--- a/.github/workflows/run_unix.yml
+++ b/.github/workflows/run_unix.yml
@@ -354,6 +354,8 @@ jobs:
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/transforms.py
     - name: Downsampling Python
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/downsampling.py
+    - name: Downsampling Median Regression Python
+      run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/downsampling_median.py
     - name: ICA Python
       run: sudo -H python3 $GITHUB_WORKSPACE/python_package/examples/tests/ica.py
     - name: CSP Python

--- a/.github/workflows/run_windows.yml
+++ b/.github/workflows/run_windows.yml
@@ -235,6 +235,9 @@ jobs:
     - name: Downsampling Python Test
       run: python %GITHUB_WORKSPACE%\python_package\examples\tests\downsampling.py
       shell: cmd
+    - name: Downsampling Median Regression Python Test
+      run: python %GITHUB_WORKSPACE%\python_package\examples\tests\downsampling_median.py
+      shell: cmd
     - name: CSP Python Test
       run: python %GITHUB_WORKSPACE%\python_package\examples\tests\csp.py
       shell: cmd

--- a/python_package/examples/tests/downsampling_median.py
+++ b/python_package/examples/tests/downsampling_median.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from brainflow.data_filter import AggOperations, DataFilter
+
+
+def main():
+    # One large outlier per window, so the median and the mean of a window are far apart
+    # and a median that silently falls back to the mean is visible.
+    data = [1.0, 2.0, 3.0, 100.0, 4.0, 5.0, 6.0, 200.0]
+
+    # Period 2 is unchanged by design. With two values the median is their mean, so this
+    # pins that the even-period path did not shift the one case that was already correct.
+    period_2 = DataFilter.perform_downsampling(np.array(data), 2, AggOperations.MEDIAN.value)
+    assert np.allclose(period_2, [1.5, 51.5, 4.5, 103.0]), period_2
+
+    # Odd periods keep the existing single middle value.
+    period_3 = DataFilter.perform_downsampling(np.array(data), 3, AggOperations.MEDIAN.value)
+    assert np.allclose(period_3, [2.0, 5.0]), period_3
+
+    # Period 4 is the regression. Each window is the mean of the two sorted middle values,
+    # (2 + 3) / 2 and (5 + 6) / 2, rather than the full-window mean downsample_median
+    # used to return for every even period.
+    period_4 = DataFilter.perform_downsampling(np.array(data), 4, AggOperations.MEDIAN.value)
+    assert np.allclose(period_4, [2.5, 5.5]), period_4
+
+    # The same windows through MEAN, to show the two operations are now distinct where
+    # they used to return identical values.
+    mean_4 = DataFilter.perform_downsampling(np.array(data), 4, AggOperations.MEAN.value)
+    assert np.allclose(mean_4, [26.5, 53.75]), mean_4
+    assert not np.allclose(period_4, mean_4), (period_4, mean_4)
+
+    mean_3 = DataFilter.perform_downsampling(np.array(data), 3, AggOperations.MEAN.value)
+    assert not np.allclose(period_3, mean_3), (period_3, mean_3)
+
+    print('downsampling median regression passed')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/data_handler/inc/downsample_operators.h
+++ b/src/data_handler/inc/downsample_operators.h
@@ -20,15 +20,17 @@ inline double downsample_each (double *data, int len)
 
 inline double downsample_median (double *data, int len)
 {
-    if (len % 2 == 0)
-    {
-        return downsample_mean (data, len);
-    }
     std::vector<double> values;
     for (int i = 0; i < len; i++)
     {
         values.push_back (data[i]);
     }
     std::sort (values.begin (), values.end ());
+    if (len % 2 == 0)
+    {
+        // for an even number of values the median is the mean of the two middle ones,
+        // same convention as RollingMedian in rolling_filter.h
+        return (values[len / 2 - 1] + values[len / 2]) / 2.0;
+    }
     return values[len / 2];
 }


### PR DESCRIPTION
`downsample_median` in `src/data_handler/inc/downsample_operators.h` short circuits to `downsample_mean` whenever the period is even. `perform_downsampling` with `AggOperations::MEDIAN` is therefore bit for bit identical to `AggOperations::MEAN` for every even period, which defeats the outlier rejection that is the only reason to choose a median filter. A single large spike inside a window passes straight through, divided by the period, instead of being discarded.

The library already contains the correct answer. `RollingMedian` in `rolling_filter.h`, which backs `perform_rolling_filter`, averages the two middle values for even window lengths. So BrainFlow has two median implementations that disagree with each other on identical input. This makes `downsample_median` follow the same convention: sort first, then average the two middle values when the length is even.

Two things worth stating precisely. `perform_rolling_filter` is not affected, only `perform_downsampling`. And at period 2 the correct even median is by definition the mean of the two values, so behaviour there is unchanged. Odd periods are unchanged.

Verified by building `libDataHandler.dylib` on macOS arm64. Input is a quiet baseline around 10.0 with one 1000.0 spike per window.

`perform_downsampling` with MEDIAN, window 0:

| period | MEDIAN before | MEDIAN after | MEAN | true median |
|---|---|---|---|---|
| 2 | 504.750000 | 504.750000 | 504.750000 | 504.750000 |
| 3 (odd) | 10.500000 | 10.500000 | 340.000000 | 10.500000 |
| 4 | 257.250000 | 9.750000 | 257.250000 | 9.750000 |
| 5 (odd) | 10.000000 | 10.000000 | 207.800000 | 10.000000 |
| 6 | 175.083333 | 10.250000 | 175.083333 | 10.250000 |
| 8 | 133.687500 | 10.000000 | 133.687500 | 10.000000 |

Spike leakage above the 10.0 baseline, which is the number that actually matters for a median filter:

| period | MEDIAN before | MEDIAN after | MEAN |
|---|---|---|---|
| 4 | +247.6250 | +0.5000 | +247.6250 |
| 6 | +165.0833 | +0.2500 | +165.0833 |
| 8 | +123.8125 | +0.2500 | +123.8125 |

Before the fix MEDIAN leaked the spike identically to MEAN. After, it rejects it.

Cross check of the two median paths on identical data, `perform_downsampling` MEDIAN against `perform_rolling_filter` MEDIAN aligned to the same windows: 10 of 10 windows mismatched at period 4 and 5 of 5 at period 8 before the fix, with 257.25 against 9.75, a 26x disagreement. 0 of 10 and 0 of 5 mismatched after.

All 9 signal processing examples that CI runs pass on this branch, and `clang-format` reports no changes on the touched file.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
