### PR TITLE
Harden Linux analysis workflows against APT mirror stalls

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -5,13 +5,16 @@ on: [push, pull_request]
 jobs:
   cppcheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Install CppCheck
+      timeout-minutes: 15
       run: |
+        sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
         sudo -H apt-get update -y
-        sudo -H apt-get install cppcheck
+        sudo -H apt-get install -y cppcheck
       env:
         DEBIAN_FRONTEND: noninteractive
     - name: Run Cppcheck

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -12,7 +12,9 @@ jobs:
     - name: Install CppCheck
       timeout-minutes: 15
       run: |
-        sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+        if [[ -f /etc/apt/apt-mirrors.txt ]]; then
+          sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+        fi
         sudo -H apt-get update -y
         sudo -H apt-get install -y cppcheck
       env:

--- a/.github/workflows/run_windows.yml
+++ b/.github/workflows/run_windows.yml
@@ -237,6 +237,7 @@ jobs:
       shell: cmd
     - name: PSD Welch Nyquist Overlap Python Test
       run: python %GITHUB_WORKSPACE%\python_package\examples\tests\psd_welch_nyquist_overlap.py
+      shell: cmd
     - name: Wavelet Buffer Size Python Test
       run: python %GITHUB_WORKSPACE%\python_package\examples\tests\wavelet_buffer_size.py
       shell: cmd

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -24,7 +24,9 @@ jobs:
     - name: Install Dependencies
       timeout-minutes: 20
       run: |
-        sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+        if [[ -f /etc/apt/apt-mirrors.txt ]]; then
+          sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
+        fi
         sudo -H apt-get update -y
         sudo -H apt-get install -y libbluetooth-dev valgrind python3-setuptools python3-pygments
       env:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   RunValgrind:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -15,15 +16,17 @@ jobs:
     steps:
     # compile and prepare env
     - name: Clone Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v7
     - name: Setup CMake
       uses: lukka/get-cmake@v4.3.2
       with:
         cmakeVersion: '3.21.4'
     - name: Install Dependencies
+      timeout-minutes: 20
       run: |
+        sudo sed -i '/azure\.archive\.ubuntu\.com/d' /etc/apt/apt-mirrors.txt
         sudo -H apt-get update -y
-        sudo -H apt-get install -y libbluetooth-dev
+        sudo -H apt-get install -y libbluetooth-dev valgrind python3-setuptools python3-pygments
       env:
         DEBIAN_FRONTEND: noninteractive
     - name: Compile BrainFlow
@@ -54,22 +57,10 @@ jobs:
         cd build
         cmake -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/installed -DCMAKE_BUILD_TYPE=Debug ..
         make
-    - name: Install Valgrind
-      run: |
-        sudo -H apt-get update -y
-        sudo -H apt-get install -y valgrind
-      env:
-        DEBIAN_FRONTEND: noninteractive
-    - name: Install Python 3.10
-      uses: actions/setup-python@v5
+    - name: Install Python 3.11
+      uses: actions/setup-python@v7
       with:
         python-version: '3.11'
-    - name: Install Python Dependencies
-      run: |
-        sudo -H apt-get update -y
-        sudo -H apt-get install -y python3-setuptools python3-pygments
-      env:
-        DEBIAN_FRONTEND: noninteractive
     - name: Install Emulator
       run: |
         cd $GITHUB_WORKSPACE/emulator


### PR DESCRIPTION
## Summary

- keep the Linux analysis workflows on the current stable `ubuntu-latest` image
- remove the unreliable first-priority Azure Ubuntu mirror before refreshing APT metadata
- tolerate runner images that do not provide `/etc/apt/apt-mirrors.txt`
- bound the CppCheck and Valgrind jobs and their package-install steps
- consolidate Valgrind's three APT setup passes into one
- update `actions/checkout` and `actions/setup-python` to v7
- run the Windows PSD Welch regression test with `cmd` so `%GITHUB_WORKSPACE%` expands correctly

## Motivation

The CppCheck and Valgrind checks for #847 both stalled in `apt-get update` against `azure.archive.ubuntu.com` and were cancelled at GitHub's six-hour hosted-job limit:

- https://github.com/brainflow-dev/brainflow/actions/runs/30890111327
- https://github.com/brainflow-dev/brainflow/actions/runs/30890111514

Both runs already used Ubuntu 24.04.4, image `20260810.271.1`. Identical workflows subsequently passed on the same image for other PRs, so changing or downgrading the runner image would not address the root cause.

GitHub's runner configuration provides `archive.ubuntu.com` and `security.ubuntu.com` as fallback mirrors. Removing only the flaky Azure entry keeps those official fallbacks available while preventing another six-hour stall. The file guard keeps the workflow compatible if a future hosted image changes its APT layout.

The first PR run also exposed a separate deterministic Windows failure: the PSD Welch test used `cmd`-style environment expansion under the default PowerShell shell. Explicitly selecting `cmd` makes it consistent with the adjacent Windows tests.

## Validation

- CppCheck completed successfully using `archive.ubuntu.com`
- Valgrind completed successfully, including all build and test steps
- parsed all three modified workflow files as YAML
- `git diff --check`
- verified the mirror rewrite removes Azure while preserving the official fallback entries
- verified the guarded rewrite succeeds both with and without the mirror-list file
- all 11 GitHub Actions workflows passed on commit `233fe60`
